### PR TITLE
SONATA-315 - Enable modal for category/collection/tags status

### DIFF
--- a/Admin/CategoryAdmin.php
+++ b/Admin/CategoryAdmin.php
@@ -69,7 +69,10 @@ class CategoryAdmin extends Admin
             ->addIdentifier('name')
             ->add('slug')
             ->add('description')
-            ->add('enabled', null, array('editable' => true))
+            ->add('enabled', null, array(
+                'editable'     => true,
+                'confirmation' => true,
+            ))
             ->add('position')
             ->add('parent')
         ;

--- a/Admin/CollectionAdmin.php
+++ b/Admin/CollectionAdmin.php
@@ -61,7 +61,10 @@ class CollectionAdmin extends Admin
             ->addIdentifier('name')
             ->add('slug')
             ->add('description')
-            ->add('enabled', null, array('editable' => true))
+            ->add('enabled', null, array(
+                'editable'     => true,
+                'confirmation' => true,
+            ))
         ;
     }
 }

--- a/Admin/TagAdmin.php
+++ b/Admin/TagAdmin.php
@@ -51,7 +51,10 @@ class TagAdmin extends Admin
         $listMapper
             ->addIdentifier('name')
             ->add('slug')
-            ->add('enabled', null, array('editable' => true))
+            ->add('enabled', null, array(
+                'editable'     => true,
+                'confirmation' => true,
+            ))
             ->add('createdAt')
             ->add('updatedAt')
         ;


### PR DESCRIPTION
Added confirmation modal for category, collection & tags `enabled` fields in administration list template.

Merge or the following PR is needed before: sonata-project/SonataAdminBundle#1873
