### PR TITLE
Small fix in the documentation

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -63,9 +63,10 @@ Installation
 
     # ...
     doctrine:
-        # ...
-        types:
-            json:     Sonata\Doctrine\Types\JsonType
+        dbal:
+            # ...
+            types:
+                json:     Sonata\Doctrine\Types\JsonType
 
 * Run the easy-extends command:
 


### PR DESCRIPTION
The Types:json:Sonata\Doctrine\Types\JsonType delcaration have to be in the dbal section.
