### PR TITLE
Fixed mapping issue if MediaBundle is not installed

### DIFF
--- a/DependencyInjection/SonataClassificationExtension.php
+++ b/DependencyInjection/SonataClassificationExtension.php
@@ -100,9 +100,8 @@ class SonataClassificationExtension extends Extension
      */
     public function registerDoctrineMapping(array $config)
     {
-
         foreach ($config['class'] as $type => $class) {
-            if (!class_exists($class)) {
+            if ('media' !== $type && !class_exists($class)) {
                 return;
             }
         }


### PR DESCRIPTION
Related to [yesterday's PR](https://github.com/sonata-project/SonataClassificationBundle/pull/62), but also required on 2.2 branch.
