### PR TITLE
Replaced stability flags by branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "symfony/symfony": "~2.3",
         "sonata-project/doctrine-orm-admin-bundle": "~2.3",
-        "sonata-project/datagrid-bundle": "~2.2@dev"
+        "sonata-project/datagrid-bundle": "2.2.x-dev"
     },
     "require-dev": {
         "friendsofsymfony/rest-bundle": "~1.1",


### PR DESCRIPTION
Replaced stability flags by branch alias as them only works for root package. For more info, refer to https://getcomposer.org/doc/04-schema.md#package-links.
By instance, I was trying to install dependencies for [SonataMediaBundle](https://github.com/sonata-project/SonataMediaBundle/blob/ee84fbe02f15e770db9435f7d56f18e0269593b2/composer.json#L25) as standalone package (for testing purposes), but I couldn't because the constraint used here.