### PR TITLE
Create BaseContext.php fixes #47

### DIFF
--- a/Document/BaseContext.php
+++ b/Document/BaseContext.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Document;
+
+use Sonata\ClassificationBundle\Model\Context as ModelContext;
+
+abstract class BaseContext extends ModelContext
+{
+    public function prePersist()
+    {
+        $this->setCreatedAt(new \DateTime);
+        $this->setUpdatedAt(new \DateTime);
+    }
+}


### PR DESCRIPTION
As requested by @Bladrak in Issue https://github.com/sonata-project/SonataClassificationBundle/issues/47.

Not tested yet.

Seems to cause the following error with the current `dev-master` of *MediaBundle* which was recently changed by @rande as mentioned in this issue:
- https://github.com/sonata-project/SonataAdminBundle/issues/2797
**MappingException in MappingException.php line 740: The target-entity Application\Sonata\ClassificationBundle\Entity\Category cannot be found in 'Application\Sonata\MediaBundle\Entity\Media#category'.**