### PR TITLE
Fix operator precedence on ContextAdmin

### DIFF
--- a/Admin/ContextAdmin.php
+++ b/Admin/ContextAdmin.php
@@ -24,7 +24,7 @@ class ContextAdmin extends Admin
     protected function configureFormFields(FormMapper $formMapper)
     {
         $formMapper
-            ->ifTrue($this->hasSubject() ? $this->getSubject()->getId() : false === null)
+            ->ifTrue(($this->hasSubject() ? $this->getSubject()->getId() : false) === null)
                 ->add('id')
             ->ifEnd()
             ->add('name')


### PR DESCRIPTION
Comparison operator has more precedence than ternary.