### PR TITLE
Update Context.orm.xml.skeleton

### DIFF
--- a/Resources/config/doctrine/Context.orm.xml.skeleton
+++ b/Resources/config/doctrine/Context.orm.xml.skeleton
@@ -13,8 +13,8 @@
         table="classification__context"
         repository-class="Doctrine\ORM\EntityRepository">
 
-        <id name="id" type="string" column="id">
-            <generator strategy="NONE"/>
+        <id name="id" type="integer" column="id">
+            <generator strategy="AUTO"/>
         </id>
 
     </entity>


### PR DESCRIPTION
The id type was varchar before, which does not support auto increment. ID should be set to int, so that context can be inserted.