### PR TITLE
`json` type for doctrine is not required

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -53,20 +53,13 @@ Installation
                         #ApplicationSonataClassificationBundle: ~
                         SonataClassificationBundle: ~
 
-* Import the ``sonata_classification.yml`` file and enable `json` type for doctrine:
+* Import the ``sonata_classification.yml`` file in your main app/config/config.yml:
 
 .. code-block:: yaml
 
     imports:
         #...
         - { resource: sonata_classification.yml }
-
-    # ...
-    doctrine:
-        dbal:
-            # ...
-            types:
-                json:     Sonata\Doctrine\Types\JsonType
 
 * Run the easy-extends command:
 


### PR DESCRIPTION
Documentation wrongly suggest adding 'json' type for doctrine but mappings in SonataClassificationBundle does not require it. In addition following documentation results in class not found exception.