### PR TITLE
fix for field not shown in the wrong circumstances

### DIFF
--- a/Admin/ContextAdmin.php
+++ b/Admin/ContextAdmin.php
@@ -24,7 +24,7 @@ class ContextAdmin extends Admin
     protected function configureFormFields(FormMapper $formMapper)
     {
         $formMapper
-            ->ifTrue($this->hasSubject() ? $this->getSubject()->getId() : false === null)
+            ->ifTrue(!($this->hasSubject() && $this->getSubject()->getId() !== null))
                 ->add('id')
             ->ifEnd()
             ->add('name')


### PR DESCRIPTION
fixes https://github.com/sonata-project/SonataClassificationBundle/issues/106
fixes https://github.com/sonata-project/sandbox/issues/509

jerome already put in a conflicting pull request at https://github.com/sonata-project/SonataClassificationBundle/pull/107, however as i commented there, always showing the id might not be intended AND cause further problems