### PR TITLE
Form category position

### DIFF
--- a/Admin/CategoryAdmin.php
+++ b/Admin/CategoryAdmin.php
@@ -96,10 +96,12 @@ class CategoryAdmin extends Admin
             }
         }
 
+        $position = $this->hasSubject() && !is_null($this->getSubject()->getPosition()) ? $this->getSubject()->getPosition() : 0;
+
         $formMapper->end()
             ->with('Options', array('class' => 'col-md-6'))
                 ->add('enabled')
-                ->add('position', 'integer', array('required' => false, 'data' => 0))
+                ->add('position', 'integer', array('required' => false, 'data' => $position))
             ->end()
         ;
 


### PR DESCRIPTION
I don't understand why position should always be set to 0,

When you try to edit a category already well positionned, we don't want to move it. (or reinit it)