### PR TITLE
Tag block

### DIFF
--- a/Block/TagsBlockService.php
+++ b/Block/TagsBlockService.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Block;
+
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\BlockBundle\Block\BaseBlockService;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\ClassificationBundle\Model\TagManagerInterface;
+use Sonata\CoreBundle\Validator\ErrorElement;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+class TagsBlockService extends BaseBlockService
+{
+    /**
+     * @var TagManagerInterface
+     */
+    protected $manager;
+
+    /**
+     * @param string              $name
+     * @param EngineInterface     $templating
+     * @param TagManagerInterface $manager
+     */
+    public function __construct($name, EngineInterface $templating, TagManagerInterface $manager)
+    {
+        $this->manager = $manager;
+
+        parent::__construct($name, $templating);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(BlockContextInterface $blockContext, Response $response = null)
+    {
+        $criteria = array(
+            'enabled' => true,
+            'context' => $blockContext->getSetting('context'),
+        );
+
+        $parameters = array(
+            'context'    => $blockContext,
+            'settings'   => $blockContext->getSettings(),
+            'block'      => $blockContext->getBlock(),
+            'pager'      => $this->manager->getPager($criteria, 1, $blockContext->getSetting('limit')),
+        );
+
+        return $this->renderResponse($blockContext->getTemplate(), $parameters, $response);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
+    {
+        $errorElement
+            ->with('settings.limit')
+                ->assertType(array(
+                    'type'       => 'integer',
+                    'acceptNull' => false,
+                ))
+            ->end()
+            ->with('settings.context')
+                ->assertNotBlank()
+            ->end()
+            ->with('settings.title')
+                ->assertNotBlank()
+                ->assertMaxLength(array('limit' => 50))
+            ->end()
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
+    {
+        $formMapper
+            ->add('settings', 'sonata_type_immutable_array', array(
+                'keys' => array(
+                    array('context', 'text', array('required' => false)),
+                    array('limit', 'integer', array('required' => false)),
+                    array('title', 'text', array('required' => false)),
+                ),
+            ))
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'Tags';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureSettings(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'limit'      => null,
+            'context'    => 'default',
+            'title'      => 'Tags',
+            'template'   => 'SonataClassificationBundle:Block:tags.html.twig',
+        ));
+    }
+}

--- a/DependencyInjection/SonataClassificationExtension.php
+++ b/DependencyInjection/SonataClassificationExtension.php
@@ -42,6 +42,7 @@ class SonataClassificationExtension extends Extension
         $loader->load('orm.xml');
         $loader->load('form.xml');
         $loader->load('serializer.xml');
+        $loader->load('block.xml');
 
         if (isset($bundles['FOSRestBundle']) && isset($bundles['NelmioApiDocBundle'])) {
             $loader->load('api_controllers.xml');

--- a/Entity/TagManager.php
+++ b/Entity/TagManager.php
@@ -29,6 +29,11 @@ class TagManager extends BaseEntityManager implements TagManagerInterface
             ->createQueryBuilder('t')
             ->select('t');
 
+        if (isset($criteria['context'])) {
+            $query->andWhere('t.context = :context');
+            $parameters['context'] = $criteria['context'];
+        }
+
         if (isset($criteria['enabled'])) {
             $query->andWhere('t.enabled = :enabled');
             $parameters['enabled'] = (bool) $criteria['enabled'];

--- a/Resources/config/block.xml
+++ b/Resources/config/block.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="sonata.classification.block.tags" class="Sonata\ClassificationBundle\Block\TagsBlockService">
+            <tag name="sonata.block" />
+
+            <argument>sonata.classification.block.tags</argument>
+            <argument type="service" id="templating" />
+            <argument type="service" id="sonata.classification.manager.tag" />
+        </service>
+    </services>
+</container>

--- a/Resources/translations/SonataClassificationBundle.de.xliff
+++ b/Resources/translations/SonataClassificationBundle.de.xliff
@@ -162,6 +162,10 @@
                 <source>breadcrumb.link_category_tree</source>
                 <target>Kategorie</target>
             </trans-unit>
+            <trans-unit id="no_tag_found">
+                <source>no_tag_found</source>
+                <target>Kein Tag gefunden.</target>
+            </trans-unit>
             <trans-unit id="active">
                 <source>active</source>
                 <target>aktiviert</target>

--- a/Resources/translations/SonataClassificationBundle.en.xliff
+++ b/Resources/translations/SonataClassificationBundle.en.xliff
@@ -158,6 +158,10 @@
                 <source>classification.tree_mode</source>
                 <target>Tree</target>
             </trans-unit>
+            <trans-unit id="no_tag_found">
+                <source>no_tag_found</source>
+                <target>No tag found.</target>
+            </trans-unit>
             <trans-unit id="breadcrumb.link_category_tree">
                 <source>breadcrumb.link_category_tree</source>
                 <target>Category</target>

--- a/Resources/translations/SonataClassificationBundle.es.xliff
+++ b/Resources/translations/SonataClassificationBundle.es.xliff
@@ -158,6 +158,10 @@
                 <source>classification.tree_mode</source>
                 <target>classification.tree_mode</target>
             </trans-unit>
+            <trans-unit id="no_tag_found">
+                <source>no_tag_found</source>
+                <target>no_tag_found</target>
+            </trans-unit>
             <trans-unit id="breadcrumb.link_category_tree">
                 <source>breadcrumb.link_category_tree</source>
                 <target>breadcrumb.link_category_tree</target>

--- a/Resources/translations/SonataClassificationBundle.fa.xliff
+++ b/Resources/translations/SonataClassificationBundle.fa.xliff
@@ -158,6 +158,10 @@
                 <source>classification.tree_mode</source>
                 <target>درخت</target>
             </trans-unit>
+            <trans-unit id="no_tag_found">
+                <source>no_tag_found</source>
+                <target>no_tag_found</target>
+            </trans-unit>
             <trans-unit id="breadcrumb.link_category_tree">
                 <source>breadcrumb.link_category_tree</source>
                 <target>breadcrumb.link_category_tree</target>

--- a/Resources/translations/SonataClassificationBundle.fr.xliff
+++ b/Resources/translations/SonataClassificationBundle.fr.xliff
@@ -154,6 +154,10 @@
                 <source>classification.tree_mode</source>
                 <target>Arbre</target>
             </trans-unit>
+            <trans-unit id="no_tag_found">
+                <source>no_tag_found</source>
+                <target>Aucun tag trouvé</target>
+            </trans-unit>
             <trans-unit id="breadcrumb.link_category_tree">
                 <source>breadcrumb.link_category_tree</source>
                 <target>Catégorie</target>

--- a/Resources/translations/SonataClassificationBundle.hu.xliff
+++ b/Resources/translations/SonataClassificationBundle.hu.xliff
@@ -158,6 +158,10 @@
                 <source>classification.tree_mode</source>
                 <target>Fa</target>
             </trans-unit>
+            <trans-unit id="no_tag_found">
+                <source>no_tag_found</source>
+                <target>Nincs címke.</target>
+            </trans-unit>
             <trans-unit id="breadcrumb.link_category_tree">
                 <source>breadcrumb.link_category_tree</source>
                 <target>breadcrumb.link_category_tree</target>

--- a/Resources/translations/SonataClassificationBundle.it.xliff
+++ b/Resources/translations/SonataClassificationBundle.it.xliff
@@ -158,6 +158,10 @@
                 <source>classification.tree_mode</source>
                 <target>Albero</target>
             </trans-unit>
+            <trans-unit id="no_tag_found">
+                <source>no_tag_found</source>
+                <target>no_tag_found</target>
+            </trans-unit>
             <trans-unit id="breadcrumb.link_category_tree">
                 <source>breadcrumb.link_category_tree</source>
                 <target>breadcrumb.link_category_tree</target>

--- a/Resources/translations/SonataClassificationBundle.nl.xliff
+++ b/Resources/translations/SonataClassificationBundle.nl.xliff
@@ -158,6 +158,10 @@
                 <source>classification.tree_mode</source>
                 <target>Structuurweergave</target>
             </trans-unit>
+            <trans-unit id="no_tag_found">
+                <source>no_tag_found</source>
+                <target>no_tag_found</target>
+            </trans-unit>
             <trans-unit id="breadcrumb.link_category_tree">
                 <source>breadcrumb.link_category_tree</source>
                 <target>breadcrumb.link_category_tree</target>

--- a/Resources/translations/SonataClassificationBundle.pt_BR.xliff
+++ b/Resources/translations/SonataClassificationBundle.pt_BR.xliff
@@ -110,6 +110,10 @@
                 <source>form.label_media</source>
                 <target>Mídia</target>
             </trans-unit>
+            <trans-unit id="no_tag_found">
+                <source>no_tag_found</source>
+                <target>no_tag_found</target>
+            </trans-unit>
             <trans-unit id="breadcrumb.link_context_list">
                 <source>breadcrumb.link_context_list</source>
                 <target>breadcrumb.link_context_list</target>

--- a/Resources/translations/SonataClassificationBundle.ro.xliff
+++ b/Resources/translations/SonataClassificationBundle.ro.xliff
@@ -158,6 +158,10 @@
                 <source>classification.tree_mode</source>
                 <target>Arbore</target>
             </trans-unit>
+            <trans-unit id="no_tag_found">
+                <source>no_tag_found</source>
+                <target>no_tag_found</target>
+            </trans-unit>
             <trans-unit id="breadcrumb.link_category_tree">
                 <source>breadcrumb.link_category_tree</source>
                 <target>breadcrumb.link_category_tree</target>

--- a/Resources/views/Block/tags.html.twig
+++ b/Resources/views/Block/tags.html.twig
@@ -1,0 +1,35 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+{% extends sonata_block.templates.block_base %}
+
+{% block block %}
+    <div class="sonata-news-block-recent-post box box-primary">
+        <div class="box-header with-border">
+            <h3 class="box-title">
+                <i class="fa fa-tags"></i> {{ settings.title }}
+            </h3>
+        </div>
+
+        <div class="box-body">
+            {% sonata_template_box 'This is the tags block.' %}
+
+            <ul class="list-group">
+                {% for tag in pager.getResults() %}
+                    <li class="list-group-item">
+                        <a href="{{ url('sonata_news_tag', { 'tag': tag.name }) }}">{{ tag.name }}</a>
+                    </li>
+                {% else %}
+                    <li class="list-group-item">{{ 'no_tag_found'|trans({}, 'SonataClassificationBundle') }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    </div>
+{% endblock %}

--- a/Tests/Block/TagsBlockServiceTest.php
+++ b/Tests/Block/TagsBlockServiceTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Tests\Block;
+
+use Sonata\BlockBundle\Tests\Block\AbstractBlockServiceTest;
+use Sonata\ClassificationBundle\Block\TagsBlockService;
+
+/**
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+class TagsBlockServiceTest extends AbstractBlockServiceTest
+{
+    public function testDefaultSettings()
+    {
+        $manager = $this->getMockBuilder('Sonata\ClassificationBundle\Model\TagManagerInterface')->disableOriginalConstructor()->getMock();
+        $pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')->disableOriginalConstructor()->getMock();
+        $blockService = new TagsBlockService('foo', $this->templating, $manager, $pool);
+        $blockContext = $this->getBlockContext($blockService);
+
+        $this->assertSettings(array(
+            'context'    => 'default',
+            'limit'      => null,
+            'title'      => 'Tags',
+            'template'   => 'SonataClassificationBundle:Block:tags.html.twig',
+        ), $blockContext);
+    }
+}


### PR DESCRIPTION
Implemented a tags block. It can be configured to use different contexts (although currently it can only accept a string). Number of displayed tags can also be configured, but limitation is disabled by default.