### PR TITLE
Add a check to prevent call function on a boolean when category and context tables are empty. fixes #159

### DIFF
--- a/Controller/CategoryAdminController.php
+++ b/Controller/CategoryAdminController.php
@@ -67,6 +67,7 @@ class CategoryAdminController extends Controller
     {
         $categoryManager = $this->get('sonata.classification.manager.category');
 
+        $mainCategory = false;
         $currentContext = false;
         if ($context = $request->get('context')) {
             $currentContext = $this->get('sonata.classification.manager.context')->find($context);
@@ -74,7 +75,7 @@ class CategoryAdminController extends Controller
 
         $rootCategories = $categoryManager->getRootCategories(false);
 
-        if (!$currentContext) {
+        if (!($currentContext || empty($rootCategories))) {
             $mainCategory   = current($rootCategories);
             $currentContext = $mainCategory->getContext();
         } else {

--- a/Resources/views/CategoryAdmin/tree.html.twig
+++ b/Resources/views/CategoryAdmin/tree.html.twig
@@ -19,29 +19,31 @@ file that was distributed with this source code.
 {% macro navigate_child(collection, admin, root, depth) %}
     <ul{% if root %} class="sonata-tree sonata-tree--toggleable js-treeview"{% endif %}>
         {% for element in collection %}
-            <li class="sonata-ba-list-field" objectId="{{ element.id }}" >
-                <div class="sonata-tree__item"{% if depth < 2 %} data-treeview-toggled{% endif %}>
-                    {% if element.parent or root %}<i class="fa fa-caret-right" data-treeview-toggler></i>{% endif %}
-                    <a class="sonata-tree__item__edit" href="{{ admin.generateObjectUrl('edit', element) }}">{{ element.name }}</a>
-                    <i class="text-muted">{{ element.description }}</i>
-                    {#<a class="label label-default pull-right" href="{{ admin.generateObjectUrl('edit', element) }}">edit <i class="fa fa-magic"></i></a>#}
-                    {% if element.enabled %}<span class="label label-success pull-right"><i class="fa fa-check"></i> {{ admin.trans('active', {}, admin.translationDomain) }}</span>{% endif %}
-                    {% if not element.enabled %}<span class="label label-danger pull-right"><i class="fa fa-times"> {{ admin.trans('disabled', {}, admin.translationDomain) }}</i></span>{% endif %}
-                </div>
+            {% if element is not empty %}
+                <li class="sonata-ba-list-field" objectId="{{ element.id }}" >
+                    <div class="sonata-tree__item"{% if depth < 2 %} data-treeview-toggled{% endif %}>
+                        {% if element.parent or root %}<i class="fa fa-caret-right" data-treeview-toggler></i>{% endif %}
+                        <a class="sonata-tree__item__edit" href="{{ admin.generateObjectUrl('edit', element) }}">{{ element.name }}</a>
+                        <i class="text-muted">{{ element.description }}</i>
+                        {#<a class="label label-default pull-right" href="{{ admin.generateObjectUrl('edit', element) }}">edit <i class="fa fa-magic"></i></a>#}
+                        {% if element.enabled %}<span class="label label-success pull-right"><i class="fa fa-check"></i> {{ admin.trans('active', {}, admin.translationDomain) }}</span>{% endif %}
+                        {% if not element.enabled %}<span class="label label-danger pull-right"><i class="fa fa-times"> {{ admin.trans('disabled', {}, admin.translationDomain) }}</i></span>{% endif %}
+                    </div>
 
-                {% if element.children|length %}
-                    {{ _self.navigate_child(element.children, admin, false, depth + 1) }}
-                {% endif %}
-            </li>
+                    {% if element.children|length %}
+                        {{ _self.navigate_child(element.children, admin, false, depth + 1) }}
+                    {% endif %}
+                </li>
+            {% endif %}
         {% endfor %}
     </ul>
 {% endmacro %}
 
 {% block tab_menu %}
     {% include 'SonataClassificationBundle:CategoryAdmin:list_tab_menu.html.twig' with {
-        'mode':   'tree',
-        'action': action,
-        'admin':  admin,
+    'mode':   'tree',
+    'action': action,
+    'admin':  admin,
     } only %}
 {% endblock %}
 
@@ -51,7 +53,7 @@ file that was distributed with this source code.
             <div class="box-header">
                 <h1 class="box-title">
                     {{ admin.trans('tree_catalog_title', {}, admin.translationdomain) }}
-                    {% if not app.request.get('hide_context') %}
+                    {% if not app.request.get('hide_context') and current_context is not empty %}
                         <div class="btn-group">
                             <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                                 <strong class="text-info">{{ current_context.name }}</strong> <span class="caret"></span>

--- a/Tests/Controller/CategoryAdminControllerTest.php
+++ b/Tests/Controller/CategoryAdminControllerTest.php
@@ -1,0 +1,282 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Tests;
+
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\ClassificationBundle\Controller\CategoryAdminController;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * Class CategoryControllerTest.
+ *
+ * @author Alexandre Tranchant <alexandre.tranchant@gmail.com>
+ */
+class CategoryAdminControllerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * @var Request
+     */
+    private $request;
+
+    /**
+     * @var CategoryAdmin
+     */
+    private $admin;
+
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @var \Sonata\ClassificationBundle\Controller\CategoryAdminController
+     */
+    private $categoryAdminController;
+
+    /**
+     * @var CsrfProviderInterface
+     */
+    private $csrfProvider;
+
+    /**
+     * @var CategoryManagerInterface
+     */
+    private $categoryManager;
+
+    /**
+     * @var ContextManagerInterface
+     */
+    private $contextManager;
+
+    /**
+     * @var DatagridInterface
+     */
+    private $dataGrid;
+
+    /**
+     * @var FormView
+     */
+    private $view;
+
+    /**
+     * @var Form
+     */
+    private $form;
+
+    /**
+     * Prepares the environment before running a test.
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->categoryAdminController = new CategoryAdminController();
+
+        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+
+        $this->categoryManager = $this->getMockBuilder('Sonata\ClassificationBundle\Entity\CategoryManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $categoryManager = $this->categoryManager;
+
+        $this->contextManager = $this->getMockBuilder('Sonata\ClassificationBundle\Entity\ContextManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $contextManager = $this->contextManager;
+
+        $this->view = $this->getMock('Symfony\Component\Form\FormView');
+
+        $this->form = $this->getMockBuilder('Symfony\Component\Form\Form')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->form->expects($this->any())
+            ->method('createView')
+            ->will($this->returnValue($this->view));
+
+        $this->dataGrid = $this->getMock('\Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $this->dataGrid->expects($this->any())
+            ->method('getForm')
+            ->will($this->returnValue($this->form));
+
+        $this->request = new Request();
+        $this->pool    = new Pool($this->container, 'title', 'logo.png');
+        $this->pool->setAdminServiceIds(array('foo.admin'));
+        $this->request->attributes->set('_sonata_admin', 'foo.admin');
+        $this->admin      = $this->getMockBuilder('Sonata\ClassificationBundle\Admin\CategoryAdmin')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->admin->expects($this->any())
+            ->method('getPersistentParameter')
+            ->will($this->returnValue('persistentParameter'));
+        $this->admin->expects($this->any())
+            ->method('getDataGrid')
+            ->will($this->returnValue($this->dataGrid));
+
+        $params = array();
+        $template = '';
+
+        $templating = $this->getMock(
+            'Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine',
+            array(),
+            array($this->container, array())
+        );
+
+        $templating->expects($this->any())
+            ->method('renderResponse')
+            ->will($this->returnCallback(function (
+                $view,
+                array $parameters = array(),
+                Response $response = null
+            ) use (
+                &$params,
+                &$template
+            ) {
+                $template = $view;
+
+                if (null === $response) {
+                    $response = new Response();
+                }
+
+                $params = $parameters;
+
+                return $response;
+            }));
+
+        $twig = $this->getMockBuilder('Twig_Environment')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $twigRenderer = $this->getMock('Symfony\Bridge\Twig\Form\TwigRendererInterface');
+
+        $formExtension = new FormExtension($twigRenderer);
+
+        $twig->expects($this->any())
+            ->method('getExtension')
+            ->will($this->returnCallback(function ($name) use ($formExtension) {
+                switch ($name) {
+                    case 'form':
+                        return $formExtension;
+                }
+
+                return;
+            }));
+
+        $this->csrfProvider = $this->getMock(
+            'Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface'
+        );
+
+        $this->csrfProvider->expects($this->any())
+            ->method('generateCsrfToken')
+            ->will($this->returnCallback(function ($intention) {
+                return 'csrf-token-123_'.$intention;
+            }));
+
+        $this->csrfProvider->expects($this->any())
+            ->method('isCsrfTokenValid')
+            ->will($this->returnCallback(function ($intention, $token) {
+                if ($token == 'csrf-token-123_'.$intention) {
+                    return true;
+                }
+
+                return false;
+            }));
+
+        // php 5.3 BC
+        $pool = $this->pool;
+        $admin = $this->admin;
+        $request = $this->request;
+        $csrfProvider = $this->csrfProvider;
+
+        $requestStack = null;
+        if (Kernel::MINOR_VERSION > 3) {
+            $requestStack = new \Symfony\Component\HttpFoundation\RequestStack();
+            $requestStack->push($request);
+        }
+
+        $this->container->expects($this->any())
+            ->method('get')
+            ->will($this->returnCallback(function ($id) use (
+                $pool,
+                $admin,
+                $request,
+                $requestStack,
+                $templating,
+                $twig,
+                $csrfProvider,
+                $categoryManager,
+                $contextManager
+            ) {
+                switch ($id) {
+                    case 'sonata.admin.pool':
+                        return $pool;
+                    case 'foo.admin':
+                        return $admin;
+                    case 'request':
+                        return $request;
+                    case 'request_stack':
+                        return $requestStack;
+                    case 'templating':
+                        return $templating;
+                    case 'twig':
+                        return $twig;
+                    case 'form.csrf_provider':
+                        return $csrfProvider;
+                    case 'sonata.classification.manager.category':
+                        return $categoryManager;
+                    case 'sonata.classification.manager.context':
+                        return $contextManager;
+                }
+
+                return;
+            }));
+
+        $this->categoryAdminController->setContainer($this->container);
+    }
+
+    /**
+     * Cleans up the environment after running a test.
+     */
+    protected function tearDown()
+    {
+        $this->categoryAdminController = null;
+        parent::tearDown();
+    }
+
+    /**
+     * Tests CategoryAdminController->tree() without data.
+     */
+    public function testTreeWithoutCategoryAndContext()
+    {
+        $this->categoryManager->expects($this->any())
+            ->method('getRootCategories')
+            ->will($this->returnValue(array()));
+        $this->contextManager->expects($this->any())
+            ->method('find')
+            ->will($this->returnValue(false));
+
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $this->categoryAdminController->treeAction($this->request));
+    }
+
+    public function getCsrfProvider()
+    {
+        return $this->csrfProvider;
+    }
+}


### PR DESCRIPTION
(Sorry, not fluent in English)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |  no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #159 
| License       | MIT

If you want to see the bug, use the ``CategoryAdminControllerTest`` to the master version and launch phpunit. I have done two modifications, the first on ``CategoryAdminController`` and the second to ``tree.html.twig``. My Controller Test only test the Controller. I don't know how to realise a unit test on ``tree.html.twig``. 

This is my first participation to a sonata bundle. I hope to do it well. I read the howto [make a pull request](http://symfony.com/doc/current/contributing/code/patches.html#make-a-pull-request) . I read the [guidelines for contributing](https://github.com/sonata-project/SonataClassificationBundle/blob/master/CONTRIBUTING.md) too.

* *You add valid test cases.* **Checked**
* *Tests are green.* **Checked**
* *The related documentation is up-to-date.* No change to documentation
* *You make the PR on the same branch you based your changes on. If you see commits that you did not make in your PR, you're doing it wrong.* I make change on fix-issue-159 branch as ask in [make a pull request](http://symfony.com/doc/current/contributing/code/patches.html#make-a-pull-request)
* *Also don't forget to add a comment when you update a PR with a ping to the maintainer (@username), so he/she will get a notification.* ping @rande 

Hope to help you, and thanks for this awesome project !