### PR TITLE
Update CategorySelectorType.php

### DIFF
--- a/Form/Type/CategorySelectorType.php
+++ b/Form/Type/CategorySelectorType.php
@@ -52,6 +52,7 @@ class CategorySelectorType extends AbstractType
             'choice_list'       => function (Options $opts, $previousValue) use ($that) {
                 return new SimpleChoiceList($that->getChoices($opts));
             },
+            'choices_as_values' => true,
         ));
     }
 


### PR DESCRIPTION
Depend on Symfony Reference. When you use version 2.7+, this options must be added, that make this bundle still work.

http://symfony.com/doc/current/reference/forms/types/choice.html#choices-as-values

```
Catchable Fatal Error: Argument 1 passed to Symfony\Component\Form\Extension\Core\Type\ChoiceType::normalizeLegacyChoices() must be of the type array, null given
```