### PR TITLE
Pass query parameters to CategoryAdminController::treeAction. Fixes #177

### DIFF
--- a/Controller/CategoryAdminController.php
+++ b/Controller/CategoryAdminController.php
@@ -32,7 +32,7 @@ class CategoryAdminController extends Controller
     public function listAction(Request $request = null)
     {
         if (!$request->get('filter') && !$request->get('filters')) {
-            return new RedirectResponse($this->admin->generateUrl('tree'));
+            return new RedirectResponse($this->admin->generateUrl('tree', $request->query->all()));
         }
 
         if ($listMode = $request->get('_list_mode')) {


### PR DESCRIPTION
Fixes #177 .
Query parameters were not passed when redirecting from CategoryAdminController::listAction
to the treeAction, thus making it impossible to filter the list by context.
This commit passes all query parameters to the redirect response.