### PR TITLE
Added abstract blocks

### DIFF
--- a/Block/Service/AbstractCategoriesBlockService.php
+++ b/Block/Service/AbstractCategoriesBlockService.php
@@ -1,0 +1,190 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Block\Service;
+
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\ClassificationBundle\Admin\CategoryAdmin;
+use Sonata\ClassificationBundle\Model\CategoryInterface;
+use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
+use Sonata\ClassificationBundle\Model\ContextManagerInterface;
+use Sonata\CoreBundle\Model\Metadata;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+abstract class AbstractCategoriesBlockService extends BaseClassificationBlockService
+{
+    /**
+     * @var CategoryManagerInterface
+     */
+    private $categoryManager;
+
+    /**
+     * @var CategoryAdmin
+     */
+    private $categoryAdmin;
+
+    /**
+     * @param string                   $name
+     * @param EngineInterface          $templating
+     * @param ContextManagerInterface  $contextManager
+     * @param CategoryManagerInterface $categoryManager
+     * @param CategoryAdmin            $categoryAdmin
+     */
+    public function __construct(
+        $name,
+        EngineInterface $templating,
+        ContextManagerInterface $contextManager,
+        CategoryManagerInterface $categoryManager,
+        CategoryAdmin $categoryAdmin
+    ) {
+        parent::__construct($name, $templating, $contextManager);
+
+        $this->categoryManager = $categoryManager;
+        $this->categoryAdmin = $categoryAdmin;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(BlockContextInterface $blockContext, Response $response = null)
+    {
+        $category = $this->getCategory($blockContext->getSetting('categoryId'), $blockContext->getSetting('category'));
+        $root = $this->categoryManager->getRootCategory($blockContext->getSetting('context'));
+
+        return $this->renderResponse($blockContext->getTemplate(), array(
+            'context' => $blockContext,
+            'settings' => $blockContext->getSettings(),
+            'block' => $blockContext->getBlock(),
+            'category' => $category,
+            'root' => $root,
+        ), $response);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
+    {
+        $adminField = $this->getFormAdminType($formMapper, $this->categoryAdmin, 'categoryId', 'category', array(
+            'label' => 'form.label_category',
+        ), array(
+            'translation_domain' => 'SonataClassificationBundle',
+            'link_parameters' => array(
+                array(
+                    array(
+                        'context' => $block->getSetting('context'),
+                    ),
+                ),
+            ),
+        ));
+
+        $formMapper->add('settings', 'sonata_type_immutable_array', array(
+            'keys' => array(
+                array('title', 'text', array(
+                    'label' => 'form.label_title',
+                    'required' => false,
+                )),
+                array('context', 'choice', array(
+                    'label' => 'form.label_context',
+                    'required' => false,
+                    'choices' => $this->getContextChoices(),
+                )),
+                array($adminField, null, array()),
+            ),
+            'translation_domain' => 'SonataClassificationBundle',
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureSettings(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'title' => 'Categories',
+            'category' => false,
+            'categoryId' => null,
+            'context' => 'default',
+            'template' => 'SonataClassificationBundle:Block:base_block_categories.html.twig',
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load(BlockInterface $block)
+    {
+        if (is_numeric($block->getSetting('categoryId', null))) {
+            $block->setSetting('categoryId', $this->getCategory($block->getSetting('categoryId', null)));
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prePersist(BlockInterface $block)
+    {
+        $this->resolveIds($block);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preUpdate(BlockInterface $block)
+    {
+        $this->resolveIds($block);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockMetadata($code = null)
+    {
+        $description = (!is_null($code) ? $code : $this->getName());
+
+        return new Metadata($this->getName(), $description, false, 'SonataClassificationBundle', array(
+            'class' => 'fa fa-folder-open-o',
+        ));
+    }
+
+    /**
+     * @param $id
+     * @param $default
+     *
+     * @return CategoryInterface
+     */
+    protected function getCategory($id, $default = false)
+    {
+        if (is_object($id)) {
+            return $id;
+        }
+
+        if (!is_null($id) && $id) {
+            return $this->categoryManager->find($id);
+        }
+
+        return $default;
+    }
+
+    /**
+     * @param BlockInterface $block
+     */
+    private function resolveIds(BlockInterface $block)
+    {
+        $block->setSetting('categoryId',
+            is_object($block->getSetting('categoryId')) ? $block->getSetting('categoryId')->getId() : null
+        );
+    }
+}

--- a/Block/Service/AbstractCollectionsBlockService.php
+++ b/Block/Service/AbstractCollectionsBlockService.php
@@ -1,0 +1,191 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Block\Service;
+
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\ClassificationBundle\Admin\CollectionAdmin;
+use Sonata\ClassificationBundle\Model\CollectionInterface;
+use Sonata\ClassificationBundle\Model\CollectionManagerInterface;
+use Sonata\ClassificationBundle\Model\ContextManagerInterface;
+use Sonata\CoreBundle\Model\Metadata;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+abstract class AbstractCollectionsBlockService extends BaseClassificationBlockService
+{
+    /**
+     * @var CollectionManagerInterface
+     */
+    private $collectionManager;
+
+    /**
+     * @var CollectionAdmin
+     */
+    private $collectionAdmin;
+
+    /**
+     * @param string                     $name
+     * @param EngineInterface            $templating
+     * @param ContextManagerInterface    $contextManager
+     * @param CollectionManagerInterface $collectionManager
+     * @param CollectionAdmin            $collectionAdmin
+     */
+    public function __construct(
+        $name,
+        EngineInterface $templating,
+        ContextManagerInterface $contextManager,
+        CollectionManagerInterface $collectionManager,
+        CollectionAdmin $collectionAdmin
+    ) {
+        parent::__construct($name, $templating, $contextManager);
+
+        $this->collectionManager = $collectionManager;
+        $this->collectionAdmin = $collectionAdmin;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(BlockContextInterface $blockContext, Response $response = null)
+    {
+        $collection = $this->getCollection($blockContext->getSetting('collectionId'), $blockContext->getSetting('collection'));
+        $collections = $this->contextManager->findBy(array(
+            'enabled' => true,
+            'context' => $blockContext->getSetting('context'),
+        ));
+
+        return $this->renderResponse($blockContext->getTemplate(), array(
+            'context' => $blockContext,
+            'settings' => $blockContext->getSettings(),
+            'block' => $blockContext->getBlock(),
+            'collection' => $collection,
+            'collections' => $collections,
+        ), $response);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
+    {
+        $adminField = $this->getFormAdminType($formMapper, $this->collectionAdmin, 'collectionId', 'collection', array(
+            'label' => 'form.label_collection',
+        ), array(
+            'translation_domain' => 'SonataClassificationBundle',
+            'link_parameters' => array(
+                array(
+                    'context' => $block->getSetting('context'),
+                ),
+            ),
+        ));
+
+        $formMapper->add('settings', 'sonata_type_immutable_array', array(
+            'keys' => array(
+                array('title', 'text', array(
+                    'label' => 'form.label_title',
+                    'required' => false,
+                )),
+                array('context', 'choice', array(
+                    'label' => 'form.label_context',
+                    'required' => false,
+                    'choices' => $this->getContextChoices(),
+                )),
+                array($adminField, null, array()),
+            ),
+            'translation_domain' => 'SonataClassificationBundle',
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureSettings(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'title' => 'Collections',
+            'collection' => false,
+            'collectionId' => null,
+            'context' => null,
+            'template' => 'SonataClassificationBundle:Block:base_block_collections.html.twig',
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load(BlockInterface $block)
+    {
+        if (is_numeric($block->getSetting('collectionId', null))) {
+            $block->setSetting('collectionId', $this->getCollection($block->getSetting('collectionId', null)));
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prePersist(BlockInterface $block)
+    {
+        $this->resolveIds($block);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preUpdate(BlockInterface $block)
+    {
+        $this->resolveIds($block);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockMetadata($code = null)
+    {
+        $description = (!is_null($code) ? $code : $this->getName());
+
+        return new Metadata($this->getName(), $description, false, 'SonataClassificationBundle', array(
+            'class' => 'fa fa-folder-open-o',
+        ));
+    }
+
+    /**
+     * @param $id
+     * @param $default
+     *
+     * @return CollectionInterface
+     */
+    protected function getCollection($id, $default = false)
+    {
+        if (is_object($id)) {
+            return $id;
+        }
+
+        if (!is_null($id) && $id) {
+            return $this->collectionManager->find($id);
+        }
+
+        return $default;
+    }
+
+    /**
+     * @param BlockInterface $block
+     */
+    private function resolveIds(BlockInterface $block)
+    {
+        $block->setSetting('collectionId',
+            is_object($block->getSetting('collectionId')) ? $block->getSetting('collectionId')->getId() : null
+        );
+    }
+}

--- a/Block/Service/AbstractTagsBlockService.php
+++ b/Block/Service/AbstractTagsBlockService.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Block\Service;
+
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\ClassificationBundle\Admin\TagAdmin;
+use Sonata\ClassificationBundle\Model\ContextInterface;
+use Sonata\ClassificationBundle\Model\ContextManagerInterface;
+use Sonata\ClassificationBundle\Model\TagInterface;
+use Sonata\ClassificationBundle\Model\TagManagerInterface;
+use Sonata\CoreBundle\Model\Metadata;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+abstract class AbstractTagsBlockService extends BaseClassificationBlockService
+{
+    /**
+     * @var TagManagerInterface
+     */
+    private $tagManager;
+
+    /**
+     * @var TagAdmin
+     */
+    private $tagAdmin;
+
+    /**
+     * @param string                  $name
+     * @param EngineInterface         $templating
+     * @param ContextManagerInterface $contextManager
+     * @param TagManagerInterface     $tagManager
+     * @param TagAdmin                $tagAdmin
+     */
+    public function __construct(
+        $name,
+        EngineInterface $templating,
+        ContextManagerInterface $contextManager,
+        TagManagerInterface $tagManager,
+        TagAdmin $tagAdmin
+    ) {
+        parent::__construct($name, $templating, $contextManager);
+
+        $this->tagManager = $tagManager;
+        $this->tagAdmin = $tagAdmin;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(BlockContextInterface $blockContext, Response $response = null)
+    {
+        $tag = $this->getTag($blockContext->getSetting('tagId'), $blockContext->getSetting('tag'));
+        $tags = $this->tagManager->findBy(array(
+            'enabled' => true,
+            'context' => $blockContext->getSetting('context'),
+        ));
+
+        return $this->renderResponse($blockContext->getTemplate(), array(
+            'context' => $blockContext,
+            'settings' => $blockContext->getSettings(),
+            'block' => $blockContext->getBlock(),
+            'tag' => $tag,
+            'tags' => $tags,
+        ), $response);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
+    {
+        $contextChoices = array();
+        /** @var ContextInterface $context */
+        foreach ($this->contextManager->findAll() as $context) {
+            $contextChoices[$context->getId()] = $context->getName();
+        }
+
+        $adminField = $this->getFormAdminType($formMapper, $this->tagAdmin, 'tagId', 'tag', array(
+            'label' => 'form.label_tag',
+        ), array(
+            'translation_domain' => 'SonataClassificationBundle',
+            'link_parameters' => array(
+                array(
+                    'context' => $block->getSetting('context'),
+                ),
+            ),
+        ));
+
+        $formMapper->add('settings', 'sonata_type_immutable_array', array(
+            'keys' => array(
+                array('title', 'text', array(
+                    'label' => 'form.label_title',
+                    'required' => false,
+                )),
+                array('context', 'choice', array(
+                    'label' => 'form.label_context',
+                    'required' => false,
+                    'choices' => $contextChoices,
+                )),
+                array($adminField, null, array()),
+            ),
+            'translation_domain' => 'SonataClassificationBundle',
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureSettings(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'title' => 'Tags',
+            'tag' => false,
+            'tagId' => null,
+            'context' => null,
+            'template' => 'SonataClassificationBundle:Block:base_block_tags.html.twig',
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load(BlockInterface $block)
+    {
+        if (is_numeric($block->getSetting('tagId', null))) {
+            $block->setSetting('tagId', $this->getTag($block->getSetting('tagId', null)));
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prePersist(BlockInterface $block)
+    {
+        $this->resolveIds($block);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preUpdate(BlockInterface $block)
+    {
+        $this->resolveIds($block);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockMetadata($code = null)
+    {
+        $description = (!is_null($code) ? $code : $this->getName());
+
+        return new Metadata($this->getName(), $description, false, 'SonataClassificationBundle', array(
+            'class' => 'fa fa-tags',
+        ));
+    }
+
+    /**
+     * @param $id
+     * @param $default
+     *
+     * @return TagInterface
+     */
+    protected function getTag($id, $default = false)
+    {
+        if (is_object($id)) {
+            return $id;
+        }
+
+        if (!is_null($id) && $id) {
+            return $this->tagManager->find($id);
+        }
+
+        return $default;
+    }
+
+    /**
+     * @param BlockInterface $block
+     */
+    private function resolveIds(BlockInterface $block)
+    {
+        $block->setSetting('tagId',
+            is_object($block->getSetting('tagId')) ? $block->getSetting('tagId')->getId() : null
+        );
+    }
+}

--- a/Block/Service/BaseClassificationBlockService.php
+++ b/Block/Service/BaseClassificationBlockService.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Block\Service;
+
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\BlockBundle\Block\BaseBlockService;
+use Sonata\ClassificationBundle\Model\ContextInterface;
+use Sonata\ClassificationBundle\Model\ContextManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Form\FormBuilder;
+
+abstract class BaseClassificationBlockService extends BaseBlockService
+{
+    /**
+     * @var ContextManagerInterface
+     */
+    protected $contextManager;
+
+    /**
+     * @param string                  $name
+     * @param EngineInterface         $templating
+     * @param ContextManagerInterface $contextManager
+     */
+    public function __construct($name, EngineInterface $templating, ContextManagerInterface $contextManager)
+    {
+        parent::__construct($name, $templating);
+
+        $this->contextManager = $contextManager;
+    }
+
+    /**
+     * @param FormMapper     $formMapper
+     * @param AdminInterface $admin
+     * @param string         $formField
+     * @param string         $field
+     * @param array          $fieldOptions
+     * @param array          $adminOptions
+     *
+     * @return FormBuilder
+     */
+    protected function getFormAdminType(
+        FormMapper $formMapper,
+        AdminInterface $admin,
+        $formField,
+        $field,
+        $fieldOptions = array(),
+        $adminOptions = array()
+    ) {
+        $adminOptions = array_merge(array(
+            'edit' => 'list',
+            'translation_domain' => 'SonataClassificationBundle',
+        ), $adminOptions);
+
+        $fieldDescription = $admin->getModelManager()->getNewFieldDescriptionInstance($admin->getClass(), $field, $adminOptions);
+        $fieldDescription->setAssociationAdmin($admin);
+        $fieldDescription->setAdmin($formMapper->getAdmin());
+        $fieldDescription->setAssociationMapping(array(
+            'fieldName' => $field,
+            'type' => ClassMetadataInfo::MANY_TO_ONE,
+        ));
+
+        $fieldOptions = array_merge(array(
+            'sonata_field_description' => $fieldDescription,
+            'class' => $admin->getClass(),
+            'model_manager' => $admin->getModelManager(),
+            'required' => false,
+        ), $fieldOptions);
+
+        return $formMapper->create($formField, 'sonata_type_model_list', $fieldOptions);
+    }
+
+    /**
+     * Returns an context choice array.
+     *
+     * @return string[]
+     */
+    protected function getContextChoices()
+    {
+        $contextChoices = array();
+        /* @var ContextInterface $context */
+        foreach ($this->contextManager->findAll() as $context) {
+            $contextChoices[$context->getId()] = $context->getName();
+        }
+
+        return $contextChoices;
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
 CHANGELOG
 =========
 
-### 2014-19-25
+## [3.x]
+### Added
 
-* add Context model to allow better classification. You can now have the 2 tags with the same slug, but with different context.
-  You can run the ``sonata:classification:fix-context`` to add missing default context after you upgrade your schema.
-* you also need to re-run the easy-extends command to generate the new ``Context`` model.
-
-### 2012-09-24
-
-* changed service parameters into options that come through the configuration with the old values as the new defaults.
+### Added
+- Added `AbstractCategoriesBlockService` class
+- Added `AbstractCollectionsBlockService` class
+- Added `AbstractTagsBlockService` class

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -13,3 +13,4 @@ Reference Guide
    reference/classification_types
    reference/advanced_configuration
    reference/media_bundle_integration
+   reference/block_bundle_integration

--- a/Resources/doc/reference/block_bundle_integration.rst
+++ b/Resources/doc/reference/block_bundle_integration.rst
@@ -1,0 +1,46 @@
+.. index::
+    single: BlockBundle
+
+BlockBundle Integration
+=======================
+
+There is an (optional) integration with the ``SonataBlockBundle``. This integration allows you to render dynamic lists on a page.
+
+Here is a sample implementation for a custom category list block:
+
+.. code-block:: php
+
+    <?php
+    class CustomCategoriesBlockService extends AbstractCategoriesBlockService
+    {
+        /**
+         * {@inheritdoc}
+         */
+        public function configureSettings(OptionsResolver $resolver)
+        {
+            parent::configureSettings($resolver);
+
+            $resolver->setDefaults(array(
+                'context'    => 'custom',
+                'template'   => 'AcmeCustomBundle:Block:block_categories.html.twig',
+            ));
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getBlockMetadata($code = null)
+        {
+            return new Metadata($this->getName(), (!is_null($code) ? $code : $this->getName()), false, 'AcmeCustomBundle', array(
+                'class' => 'fa fa-folder-open-o',
+            ));
+        }
+    }
+
+
+.. code-block:: twig
+
+    {% extends 'SonataClassificationBundle:Block:base_block_categories.html.twig' %}
+
+    {% block link_category %}<a href="{{ path('acme_custom_category', { 'category': item.slug }) }}">{{ item.name }}</a>{% endblock %}
+

--- a/Resources/translations/SonataClassificationBundle.de.xliff
+++ b/Resources/translations/SonataClassificationBundle.de.xliff
@@ -170,6 +170,34 @@
                 <source>disabled</source>
                 <target>deaktiviert</target>
             </trans-unit>
+            <trans-unit id="form.label_category">
+                <source>form.label_category</source>
+                <target>Kategorie</target>
+            </trans-unit>
+            <trans-unit id="form.label_collection">
+                <source>form.label_collection</source>
+                <target>Sammlung</target>
+            </trans-unit>
+            <trans-unit id="form.label_tag">
+                <source>form.label_tag</source>
+                <target>Schlüsselwort</target>
+            </trans-unit>
+            <trans-unit id="form.label_title">
+                <source>form.label_title</source>
+                <target>Titel</target>
+            </trans-unit>
+            <trans-unit id="no_collections_found">
+                <source>no_collections_found</source>
+                <target>Es konnten keine Sammlungen gefunden werden.</target>
+            </trans-unit>
+            <trans-unit id="no_categories_found">
+                <source>no_categories_found</source>
+                <target>Es konnten keine Kategorien gefunden werden.</target>
+            </trans-unit>
+            <trans-unit id="no_tags_found">
+                <source>no_tags_found</source>
+                <target>Es konnten keine Schlüsselworte gefunden werden.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataClassificationBundle.en.xliff
+++ b/Resources/translations/SonataClassificationBundle.en.xliff
@@ -170,6 +170,34 @@
                 <source>disabled</source>
                 <target>disabled</target>
             </trans-unit>
+            <trans-unit id="form.label_category">
+                <source>form.label_category</source>
+                <target>Category</target>
+            </trans-unit>
+            <trans-unit id="form.label_collection">
+                <source>form.label_collection</source>
+                <target>Collection</target>
+            </trans-unit>
+            <trans-unit id="form.label_tag">
+                <source>form.label_tag</source>
+                <target>Tag</target>
+            </trans-unit>
+            <trans-unit id="form.label_title">
+                <source>form.label_title</source>
+                <target>Title</target>
+            </trans-unit>
+            <trans-unit id="no_collections_found">
+                <source>no_collections_found</source>
+                <target>No collections found.</target>
+            </trans-unit>
+            <trans-unit id="no_categories_found">
+                <source>no_categories_found</source>
+                <target>No categories found.</target>
+            </trans-unit>
+            <trans-unit id="no_tags_found">
+                <source>no_tags_found</source>
+                <target>No tags found.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataClassificationBundle.es.xliff
+++ b/Resources/translations/SonataClassificationBundle.es.xliff
@@ -170,6 +170,34 @@
                 <source>disabled</source>
                 <target>disabled</target>
             </trans-unit>
+            <trans-unit id="form.label_category">
+                <source>form.label_category</source>
+                <target>form.label_category</target>
+            </trans-unit>
+            <trans-unit id="form.label_collection">
+                <source>form.label_collection</source>
+                <target>form.label_collection</target>
+            </trans-unit>
+            <trans-unit id="form.label_tag">
+                <source>form.label_tag</source>
+                <target>form.label_tag</target>
+            </trans-unit>
+            <trans-unit id="form.label_title">
+                <source>form.label_title</source>
+                <target>form.label_title</target>
+            </trans-unit>
+            <trans-unit id="no_collections_found">
+                <source>no_collections_found</source>
+                <target>no_collections_found</target>
+            </trans-unit>
+            <trans-unit id="no_categories_found">
+                <source>no_categories_found</source>
+                <target>no_categories_found</target>
+            </trans-unit>
+            <trans-unit id="no_tags_found">
+                <source>no_tags_found</source>
+                <target>no_tags_found</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataClassificationBundle.fa.xliff
+++ b/Resources/translations/SonataClassificationBundle.fa.xliff
@@ -170,6 +170,34 @@
                 <source>disabled</source>
                 <target>disabled</target>
             </trans-unit>
+            <trans-unit id="form.label_category">
+                <source>form.label_category</source>
+                <target>form.label_category</target>
+            </trans-unit>
+            <trans-unit id="form.label_collection">
+                <source>form.label_collection</source>
+                <target>form.label_collection</target>
+            </trans-unit>
+            <trans-unit id="form.label_tag">
+                <source>form.label_tag</source>
+                <target>form.label_tag</target>
+            </trans-unit>
+            <trans-unit id="form.label_title">
+                <source>form.label_title</source>
+                <target>form.label_title</target>
+            </trans-unit>
+            <trans-unit id="no_collections_found">
+                <source>no_collections_found</source>
+                <target>no_collections_found</target>
+            </trans-unit>
+            <trans-unit id="no_categories_found">
+                <source>no_categories_found</source>
+                <target>no_categories_found</target>
+            </trans-unit>
+            <trans-unit id="no_tags_found">
+                <source>no_tags_found</source>
+                <target>no_tags_found</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataClassificationBundle.fr.xliff
+++ b/Resources/translations/SonataClassificationBundle.fr.xliff
@@ -166,6 +166,34 @@
                 <source>disabled</source>
                 <target>Désactivé</target>
             </trans-unit>
+            <trans-unit id="form.label_category">
+                <source>form.label_category</source>
+                <target>form.label_category</target>
+            </trans-unit>
+            <trans-unit id="form.label_collection">
+                <source>form.label_collection</source>
+                <target>form.label_collection</target>
+            </trans-unit>
+            <trans-unit id="form.label_tag">
+                <source>form.label_tag</source>
+                <target>form.label_tag</target>
+            </trans-unit>
+            <trans-unit id="form.label_title">
+                <source>form.label_title</source>
+                <target>form.label_title</target>
+            </trans-unit>
+            <trans-unit id="no_collections_found">
+                <source>no_collections_found</source>
+                <target>no_collections_found</target>
+            </trans-unit>
+            <trans-unit id="no_categories_found">
+                <source>no_categories_found</source>
+                <target>no_categories_found</target>
+            </trans-unit>
+            <trans-unit id="no_tags_found">
+                <source>no_tags_found</source>
+                <target>no_tags_found</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataClassificationBundle.hu.xliff
+++ b/Resources/translations/SonataClassificationBundle.hu.xliff
@@ -170,6 +170,34 @@
                 <source>disabled</source>
                 <target>disabled</target>
             </trans-unit>
+            <trans-unit id="form.label_category">
+                <source>form.label_category</source>
+                <target>form.label_category</target>
+            </trans-unit>
+            <trans-unit id="form.label_collection">
+                <source>form.label_collection</source>
+                <target>form.label_collection</target>
+            </trans-unit>
+            <trans-unit id="form.label_tag">
+                <source>form.label_tag</source>
+                <target>form.label_tag</target>
+            </trans-unit>
+            <trans-unit id="form.label_title">
+                <source>form.label_title</source>
+                <target>form.label_title</target>
+            </trans-unit>
+            <trans-unit id="no_collections_found">
+                <source>no_collections_found</source>
+                <target>no_collections_found</target>
+            </trans-unit>
+            <trans-unit id="no_categories_found">
+                <source>no_categories_found</source>
+                <target>no_categories_found</target>
+            </trans-unit>
+            <trans-unit id="no_tags_found">
+                <source>no_tags_found</source>
+                <target>no_tags_found</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataClassificationBundle.it.xliff
+++ b/Resources/translations/SonataClassificationBundle.it.xliff
@@ -170,6 +170,34 @@
                 <source>disabled</source>
                 <target>disabled</target>
             </trans-unit>
+            <trans-unit id="form.label_category">
+                <source>form.label_category</source>
+                <target>form.label_category</target>
+            </trans-unit>
+            <trans-unit id="form.label_collection">
+                <source>form.label_collection</source>
+                <target>form.label_collection</target>
+            </trans-unit>
+            <trans-unit id="form.label_tag">
+                <source>form.label_tag</source>
+                <target>form.label_tag</target>
+            </trans-unit>
+            <trans-unit id="form.label_title">
+                <source>form.label_title</source>
+                <target>form.label_title</target>
+            </trans-unit>
+            <trans-unit id="no_collections_found">
+                <source>no_collections_found</source>
+                <target>no_collections_found</target>
+            </trans-unit>
+            <trans-unit id="no_categories_found">
+                <source>no_categories_found</source>
+                <target>no_categories_found</target>
+            </trans-unit>
+            <trans-unit id="no_tags_found">
+                <source>no_tags_found</source>
+                <target>no_tags_found</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataClassificationBundle.ja.xliff
+++ b/Resources/translations/SonataClassificationBundle.ja.xliff
@@ -158,6 +158,34 @@
                 <source>classification.tree_mode</source>
                 <target>ツリー</target>
             </trans-unit>
+            <trans-unit id="form.label_category">
+                <source>form.label_category</source>
+                <target>form.label_category</target>
+            </trans-unit>
+            <trans-unit id="form.label_collection">
+                <source>form.label_collection</source>
+                <target>form.label_collection</target>
+            </trans-unit>
+            <trans-unit id="form.label_tag">
+                <source>form.label_tag</source>
+                <target>form.label_tag</target>
+            </trans-unit>
+            <trans-unit id="form.label_title">
+                <source>form.label_title</source>
+                <target>form.label_title</target>
+            </trans-unit>
+            <trans-unit id="no_collections_found">
+                <source>no_collections_found</source>
+                <target>no_collections_found</target>
+            </trans-unit>
+            <trans-unit id="no_categories_found">
+                <source>no_categories_found</source>
+                <target>no_categories_found</target>
+            </trans-unit>
+            <trans-unit id="no_tags_found">
+                <source>no_tags_found</source>
+                <target>no_tags_found</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataClassificationBundle.nl.xliff
+++ b/Resources/translations/SonataClassificationBundle.nl.xliff
@@ -170,6 +170,34 @@
                 <source>disabled</source>
                 <target>disabled</target>
             </trans-unit>
+            <trans-unit id="form.label_category">
+                <source>form.label_category</source>
+                <target>form.label_category</target>
+            </trans-unit>
+            <trans-unit id="form.label_collection">
+                <source>form.label_collection</source>
+                <target>form.label_collection</target>
+            </trans-unit>
+            <trans-unit id="form.label_tag">
+                <source>form.label_tag</source>
+                <target>form.label_tag</target>
+            </trans-unit>
+            <trans-unit id="form.label_title">
+                <source>form.label_title</source>
+                <target>form.label_title</target>
+            </trans-unit>
+            <trans-unit id="no_collections_found">
+                <source>no_collections_found</source>
+                <target>no_collections_found</target>
+            </trans-unit>
+            <trans-unit id="no_categories_found">
+                <source>no_categories_found</source>
+                <target>no_categories_found</target>
+            </trans-unit>
+            <trans-unit id="no_tags_found">
+                <source>no_tags_found</source>
+                <target>no_tags_found</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataClassificationBundle.pt_BR.xliff
+++ b/Resources/translations/SonataClassificationBundle.pt_BR.xliff
@@ -170,6 +170,34 @@
                 <source>disabled</source>
                 <target>disabled</target>
             </trans-unit>
+            <trans-unit id="form.label_category">
+                <source>form.label_category</source>
+                <target>form.label_category</target>
+            </trans-unit>
+            <trans-unit id="form.label_collection">
+                <source>form.label_collection</source>
+                <target>form.label_collection</target>
+            </trans-unit>
+            <trans-unit id="form.label_tag">
+                <source>form.label_tag</source>
+                <target>form.label_tag</target>
+            </trans-unit>
+            <trans-unit id="form.label_title">
+                <source>form.label_title</source>
+                <target>form.label_title</target>
+            </trans-unit>
+            <trans-unit id="no_collections_found">
+                <source>no_collections_found</source>
+                <target>no_collections_found</target>
+            </trans-unit>
+            <trans-unit id="no_categories_found">
+                <source>no_categories_found</source>
+                <target>no_categories_found</target>
+            </trans-unit>
+            <trans-unit id="no_tags_found">
+                <source>no_tags_found</source>
+                <target>no_tags_found</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataClassificationBundle.ro.xliff
+++ b/Resources/translations/SonataClassificationBundle.ro.xliff
@@ -170,6 +170,34 @@
                 <source>disabled</source>
                 <target>disabled</target>
             </trans-unit>
+            <trans-unit id="form.label_category">
+                <source>form.label_category</source>
+                <target>form.label_category</target>
+            </trans-unit>
+            <trans-unit id="form.label_collection">
+                <source>form.label_collection</source>
+                <target>form.label_collection</target>
+            </trans-unit>
+            <trans-unit id="form.label_tag">
+                <source>form.label_tag</source>
+                <target>form.label_tag</target>
+            </trans-unit>
+            <trans-unit id="form.label_title">
+                <source>form.label_title</source>
+                <target>form.label_title</target>
+            </trans-unit>
+            <trans-unit id="no_collections_found">
+                <source>no_collections_found</source>
+                <target>no_collections_found</target>
+            </trans-unit>
+            <trans-unit id="no_categories_found">
+                <source>no_categories_found</source>
+                <target>no_categories_found</target>
+            </trans-unit>
+            <trans-unit id="no_tags_found">
+                <source>no_tags_found</source>
+                <target>no_tags_found</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/views/Block/base_block_categories.html.twig
+++ b/Resources/views/Block/base_block_categories.html.twig
@@ -1,0 +1,87 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+{% extends sonata_block.templates.block_base %}
+
+{% block block %}
+    <div class="panel panel-default panel-category-list">
+        {% if settings.title is not empty %}
+            <div class="panel-heading">
+                <h4 class="panel-title"><i class="fa fa-folder-open-o"></i> {{ settings.title }}</h4>
+            </div>
+        {% endif %}
+
+        <div class="panel-body">
+            {% if root.children|length %}
+                <ul class="nav nav-pills nav-stacked">
+                    {% set item = root %}
+                    {% set active = category %}
+                    {{ block('children') }}
+                </ul>
+            {% else %}
+                <p>{{ 'no_categories_found'|trans({}, 'SonataClassificationBundle') }}</p>
+            {% endif %}
+        </div>
+    </div>
+{% endblock %}
+
+{% macro attributes(attributes) %}
+    {% for name, value in attributes %}
+        {%- if value is not none and value is not sameas(false) -%}
+            {{- ' %s="%s"'|format(name, value is sameas(true) ? name|e : value|e)|raw -}}
+        {%- endif -%}
+    {%- endfor -%}
+{% endmacro %}
+
+{% block list %}
+    {% if item.children|length %}
+        <ul>
+            {{ block('children') }}
+        </ul>
+    {% endif %}
+{% endblock %}
+
+{% block children %}
+    {# save current variables #}
+    {% set currentItem = item %}
+    {% for item in currentItem.children %}
+        {{ block('item') }}
+    {% endfor %}
+    {# restore current variables #}
+    {% set item = currentItem %}
+{% endblock %}
+
+{% block item %}
+    {# building the class of the item #}
+    {%- set classes = [] %}
+    {%- if active and active.id == item.id %}
+        {%- set classes = classes|merge(['active']) %}
+    {%- endif %}
+    {%- if loop.first %}
+        {%- set classes = classes|merge(['first']) %}
+    {%- endif %}
+    {%- if loop.last %}
+        {%- set classes = classes|merge(['last']) %}
+    {%- endif %}
+
+    {%- set attributes = [] %}
+    {%- if classes is not empty %}
+        {%- set attributes = attributes|merge({'class': classes|join(' ')}) %}
+    {%- endif %}
+    <li{{ _self.attributes(attributes) }}>
+        {{ block('link_category') }}
+        {# render the list of children#}
+        {{ block('list') }}
+    </li>
+{% endblock %}
+
+{% block link_category %}{{ block('label') }}{% endblock %}
+
+{% block label %}{{ category.name }}{% endblock %}

--- a/Resources/views/Block/base_block_collections.html.twig
+++ b/Resources/views/Block/base_block_collections.html.twig
@@ -1,0 +1,37 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+{% extends sonata_block.templates.block_base %}
+
+{% block block %}
+    <div class="panel panel-default panel-collection-list">
+        {% if settings.title is not empty %}
+            <div class="panel-heading">
+                <h4 class="panel-title"><i class="fa fa-inpanel"></i> {{ settings.title }}</h4>
+            </div>
+        {% endif %}
+
+        <div class="panel-body">
+            {% if collections|length %}
+                <ul class="nav nav-pills nav-stacked">
+                    {% for col in collections %}
+                        <li{{ collection and collection.id == col.id ? ' class="active"' : '' }}>
+                            {% block collection_link %}
+                                {{ col.name }}
+                            {% endblock %}
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% else %}
+                <p>{{ 'no_collections_found'|trans({}, 'SonataClassificationBundle') }}</p>
+            {% endif %}
+        </div>
+    </div>
+{% endblock %}

--- a/Resources/views/Block/base_block_tags.html.twig
+++ b/Resources/views/Block/base_block_tags.html.twig
@@ -1,0 +1,33 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+{% extends sonata_block.templates.block_base %}
+
+{% block block %}
+    <div class="panel panel-default panel-tag-list">
+        {% if settings.title is not empty %}
+            <div class="panel-heading">
+                <h4 class="panel-title"><i class="fa fa-tags"></i> {{ settings.title }}</h4>
+            </div>
+        {% endif %}
+
+        <div class="panel-body">
+            {% if tags|length %}
+                {% for t in tags %}
+                    {% block tag_link %}
+                        <span class="label label-default"><i class="fa fa-tag"></i> {{ t.name }}</span>
+                    {% endblock %}
+                {% endfor %}
+            {% else %}
+                <p>{{ 'no_tags_found'|trans({}, 'SonataClassificationBundle') }}</p>
+            {% endif %}
+        </div>
+    </div>
+{% endblock %}

--- a/Tests/Block/Service/AbstractCategoriesBlockServiceTest.php
+++ b/Tests/Block/Service/AbstractCategoriesBlockServiceTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Tests\Block\Service;
+
+use Sonata\BlockBundle\Tests\Block\AbstractBlockServiceTest;
+use Sonata\BlockBundle\Tests\Block\Service\FakeTemplating;
+use Sonata\ClassificationBundle\Admin\CategoryAdmin;
+use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
+use Sonata\ClassificationBundle\Model\ContextManagerInterface;
+
+class AbstractCategoriesBlockServiceTest extends AbstractBlockServiceTest
+{
+    /**
+     * @var FakeTemplating
+     */
+    protected $templating;
+
+    /**
+     * @var ContextManagerInterface
+     */
+    protected $contextManager;
+
+    /**
+     * @var CategoryManagerInterface
+     */
+    protected $categoryManager;
+
+    /**
+     * @var CategoryAdmin
+     */
+    protected $categoryAdmin;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->templating = new FakeTemplating();
+        $this->contextManager = $this->getMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $this->categoryManager = $this->getMock('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
+        $this->categoryAdmin = $this->getMockBuilder('Sonata\ClassificationBundle\Admin\CategoryAdmin')->disableOriginalConstructor()->getMock();
+    }
+
+    public function testDefaultSettings()
+    {
+        $blockService = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Block\Service\AbstractCategoriesBlockService', array(
+            'block.service', $this->templating, $this->contextManager, $this->categoryManager, $this->categoryAdmin,
+        ));
+        $blockContext = $this->getBlockContext($blockService);
+
+        $this->assertSettings(array(
+            'title' => 'Categories',
+            'category' => false,
+            'categoryId' => null,
+            'context' => 'default',
+            'template' => 'SonataClassificationBundle:Block:base_block_categories.html.twig',
+        ), $blockContext);
+    }
+}

--- a/Tests/Block/Service/AbstractCollectionsBlockServiceTest.php
+++ b/Tests/Block/Service/AbstractCollectionsBlockServiceTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Tests\Block\Service;
+
+use Sonata\BlockBundle\Tests\Block\AbstractBlockServiceTest;
+use Sonata\BlockBundle\Tests\Block\Service\FakeTemplating;
+use Sonata\ClassificationBundle\Admin\CollectionAdmin;
+use Sonata\ClassificationBundle\Model\CollectionManagerInterface;
+use Sonata\ClassificationBundle\Model\ContextManagerInterface;
+
+class AbstractCollectionsBlockServiceTest extends AbstractBlockServiceTest
+{
+    /**
+     * @var FakeTemplating
+     */
+    protected $templating;
+
+    /**
+     * @var ContextManagerInterface
+     */
+    protected $contextManager;
+
+    /**
+     * @var CollectionManagerInterface
+     */
+    protected $collectionManager;
+
+    /**
+     * @var CollectionAdmin
+     */
+    protected $collectionAdmin;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->templating = new FakeTemplating();
+        $this->contextManager = $this->getMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $this->collectionManager = $this->getMock('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
+        $this->collectionAdmin = $this->getMockBuilder('Sonata\ClassificationBundle\Admin\CollectionAdmin')->disableOriginalConstructor()->getMock();
+    }
+
+    public function testDefaultSettings()
+    {
+        $blockService = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Block\Service\AbstractCollectionsBlockService', array(
+            'block.service', $this->templating, $this->contextManager, $this->collectionManager, $this->collectionAdmin,
+        ));
+        $blockContext = $this->getBlockContext($blockService);
+
+        $this->assertSettings(array(
+            'title' => 'Collections',
+            'collection' => false,
+            'collectionId' => null,
+            'context' => null,
+            'template' => 'SonataClassificationBundle:Block:base_block_collections.html.twig',
+        ), $blockContext);
+    }
+}

--- a/Tests/Block/Service/AbstractTagsBlockServiceTest.php
+++ b/Tests/Block/Service/AbstractTagsBlockServiceTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Tests\Block\Service;
+
+use Sonata\AdminBundle\Tests\Fixtures\Admin\TagAdmin;
+use Sonata\BlockBundle\Tests\Block\AbstractBlockServiceTest;
+use Sonata\BlockBundle\Tests\Block\Service\FakeTemplating;
+use Sonata\ClassificationBundle\Model\ContextManagerInterface;
+use Sonata\ClassificationBundle\Model\TagManagerInterface;
+
+class AbstractTagsBlockServiceTest extends AbstractBlockServiceTest
+{
+    /**
+     * @var FakeTemplating
+     */
+    protected $templating;
+
+    /**
+     * @var ContextManagerInterface
+     */
+    protected $contextManager;
+
+    /**
+     * @var TagManagerInterface
+     */
+    protected $tagManager;
+
+    /**
+     * @var TagAdmin
+     */
+    protected $tagAdmin;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->templating = new FakeTemplating();
+        $this->contextManager = $this->getMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $this->tagManager = $this->getMock('Sonata\ClassificationBundle\Model\TagManagerInterface');
+        $this->tagAdmin = $this->getMockBuilder('Sonata\ClassificationBundle\Admin\TagAdmin')->disableOriginalConstructor()->getMock();
+    }
+
+    public function testDefaultSettings()
+    {
+        $blockService = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Block\Service\AbstractTagsBlockService', array(
+            'block.service', $this->templating, $this->contextManager, $this->tagManager, $this->tagAdmin,
+        ));
+        $blockContext = $this->getBlockContext($blockService);
+
+        $this->assertSettings(array(
+            'title' => 'Tags',
+            'tag' => false,
+            'tagId' => null,
+            'context' => null,
+            'template' => 'SonataClassificationBundle:Block:base_block_tags.html.twig',
+        ), $blockContext);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -26,14 +26,17 @@
     "require-dev": {
         "friendsofsymfony/rest-bundle": "^1.1",
         "jms/serializer-bundle": "~0.11 || ^1.0",
+        "sonata-project/block-bundle": "^3.0",
         "sonata-project/media-bundle": "^3.0@dev",
         "symfony/phpunit-bridge": "^2.7 || ^3.0"
     },
     "suggest": {
+        "sonata-project/block-bundle": "For rendering dynamic list blocks on a page.",
         "sonata-project/media-bundle": "For media management"
     },
     "conflict": {
-        "jms/serializer": "<0.13"
+        "jms/serializer": "<0.13",
+        "sonata-project/block-bundle": "<3.0 || >=4.0"
     },
     "autoload": {
         "psr-4": { "Sonata\\ClassificationBundle\\": "" }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Added
- Added `AbstractCategoriesBlockService` class
- Added `AbstractCollectionsBlockService` class
- Added `AbstractTagsBlockService` class
```

### Subject

This adds some basic blocks that can be used in other bundles.

It does nearly the same as #143, but adds some more blocks for collections and categories and has a better abstraction layer for other bundles.

### To do

<!--
    Complete the tasks.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

- [X] Added abstract blocks for categories, collections and tags
- [X] Update the tests
- [X] Update the documentation

