### PR TITLE
Missing the proper schema update

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -101,3 +101,9 @@ Installation
                     mappings:
                         ApplicationSonataClassificationBundle: ~
                         # ...
+
+* Update the schema:
+
+.. code-block:: bash
+
+    php bin/console doctrine:schema:update --force


### PR DESCRIPTION
As the last step of the installation process, an update to the schema is required. This quite important step is missing at the end of the doc and, in my opinion, should be added. A non expert user could not understand what's happening when get errors via the Sonata Admin Interface: in fact the actions are regularly displayed in the dashboard and the errors are triggered only the create process with the form submit