### PR TITLE
Use ContextAwareAdmin for collection and category

### DIFF
--- a/Admin/CategoryAdmin.php
+++ b/Admin/CategoryAdmin.php
@@ -11,13 +11,12 @@
 
 namespace Sonata\ClassificationBundle\Admin;
 
-use Sonata\AdminBundle\Admin\Admin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Route\RouteCollection;
 
-class CategoryAdmin extends Admin
+class CategoryAdmin extends ContextAwareAdmin
 {
     protected $formOptions = array(
         'cascade_validation' => true,

--- a/Admin/CollectionAdmin.php
+++ b/Admin/CollectionAdmin.php
@@ -11,12 +11,11 @@
 
 namespace Sonata\ClassificationBundle\Admin;
 
-use Sonata\AdminBundle\Admin\Admin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 
-class CollectionAdmin extends Admin
+class CollectionAdmin extends ContextAwareAdmin
 {
     protected $formOptions = array(
         'cascade_validation' => true,


### PR DESCRIPTION
Fixed a bug introduced in https://github.com/sonata-project/SonataClassificationBundle/pull/154. You can't filter categories and collections by context anymore.

This adds the missing `ContextAwareAdmin` to the `CategoryAdmin` and `CollectionAdmin` class.