### PR TITLE
Replace the global symfony dependency by only necessary components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,13 @@
     ],
     "require": {
         "php": "^5.3 || ^7.0",
-        "symfony/framework-bundle": "^2.3 || ^3.0",
-        "symfony/form": "^2.3 || ^3.0",
+        "symfony/config": "^2.3.9 || ^3.0",
+        "symfony/console": "^2.3 || ^3.0",
+        "symfony/dependency-injection": "^2.3.3 || ^3.0",
+        "symfony/form": "^2.3.5 || ^3.0",
+        "symfony/http-foundation": "^2.3 || ^3.0",
+        "symfony/http-kernel": "^2.3 || ^3.0",
+        "symfony/options-resolver": "^2.3 || ^3.0",
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
         "sonata-project/admin-bundle": "^3.0",
         "sonata-project/datagrid-bundle": "^2.2"


### PR DESCRIPTION
### Changelog

```markdown
### Removed
- Some unneeded Symfony dependencies
```

### Subject

This PR is the same as https://github.com/sonata-project/SonataClassificationBundle/pull/194 who needed to be rebase on 3.x branch.
