### PR TITLE
Fixed wrong mongodb properties

### DIFF
--- a/Resources/config/doctrine/BaseCategory.mongodb.xml
+++ b/Resources/config/doctrine/BaseCategory.mongodb.xml
@@ -11,7 +11,6 @@
         <field name="slug"          type="string"       fieldName="slug"    />
 
         <field name="description"   type="string"   fieldName="description"    />
-        <field name="count"         type="int"      fieldName="count"          />
 
         <field name="createdAt"    type="timestamp"   fieldName="createdAt" />
         <field name="updatedAt"    type="timestamp"   fieldName="updatedAt" />

--- a/Resources/config/doctrine/BaseContext.mongodb.xml
+++ b/Resources/config/doctrine/BaseContext.mongodb.xml
@@ -6,8 +6,8 @@
 
     <mapped-superclass name="Sonata\ClassificationBundle\Document\BaseContext">
 
+        <field name="name"          type="string"       column="name" />
         <field name="enabled"       type="boolean"      fieldName="enabled" />
-        <field name="slug"          type="string"       fieldName="slug"    />
 
         <field name="createdAt"     type="timestamp"    fieldName="createdAt" />
         <field name="updatedAt"     type="timestamp"    fieldName="updatedAt" />


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataClassificationBundle/issues/174

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Fixed
- Removed unmapped `count` property in `BaseCategory.mongodb.xml`
- Renamed wrong `slug` property to `name` in `BaseContext.mongodb.xml`
```

### Subject

Fixed wrong and unmapped mongodb properties.
