### PR TITLE
Document, Tag and Collection manager classes don't respect PageableManagerInterface

### DIFF
--- a/Document/CategoryManager.php
+++ b/Document/CategoryManager.php
@@ -22,7 +22,7 @@ class CategoryManager extends BaseDocumentManager implements CategoryManagerInte
     /**
      * {@inheritdoc}
      */
-    public function getPager(array $criteria, $page, $maxPerPage = 10)
+    public function getPager(array $criteria, $page, $limit = 10, array $sort = array())
     {
         $parameters = array();
 
@@ -37,7 +37,7 @@ class CategoryManager extends BaseDocumentManager implements CategoryManagerInte
         $query->setParameters($parameters);
 
         $pager = new Pager();
-        $pager->setMaxPerPage($maxPerPage);
+        $pager->setMaxPerPage($limit);
         $pager->setQuery(new ProxyQuery($query));
         $pager->setPage($page);
         $pager->init();

--- a/Document/CollectionManager.php
+++ b/Document/CollectionManager.php
@@ -22,7 +22,7 @@ class CollectionManager extends BaseDocumentManager implements CollectionManager
     /**
      * {@inheritdoc}
      */
-    public function getPager(array $criteria, $page, $maxPerPage = 10)
+    public function getPager(array $criteria, $page, $limit = 10, array $sort = array())
     {
         $parameters = array();
 
@@ -37,7 +37,7 @@ class CollectionManager extends BaseDocumentManager implements CollectionManager
         $query->setParameters($parameters);
 
         $pager = new Pager();
-        $pager->setMaxPerPage($maxPerPage);
+        $pager->setMaxPerPage($limit);
         $pager->setQuery(new ProxyQuery($query));
         $pager->setPage($page);
         $pager->init();

--- a/Document/TagManager.php
+++ b/Document/TagManager.php
@@ -20,7 +20,7 @@ class TagManager extends BaseDocumentManager implements TagManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function getPager(array $criteria, $page, $maxPerPage = 10)
+    public function getPager(array $criteria, $page, $limit = 10, array $sort = array())
     {
         $parameters = array();
 
@@ -35,7 +35,7 @@ class TagManager extends BaseDocumentManager implements TagManagerInterface
         $query->setParameters($parameters);
 
         $pager = new Pager();
-        $pager->setMaxPerPage($maxPerPage);
+        $pager->setMaxPerPage($limit);
         $pager->setQuery(new ProxyQuery($query));
         $pager->setPage($page);
         $pager->init();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown

### Changed
- TagManager.php to respect PageableManagerInterface
- CollectionManager.php to respect PageableManagerInterface
- CategoryManager.php to respect PageableManagerInterface
```

### Subject

In order to implements PageableManagerInterface (~2.2), `getPager` method of TagManager, CollectionManager and CategoryManager have to be changed.

This PR affects 2.x branch. See previous PR https://github.com/sonata-project/SonataClassificationBundle/pull/186