### PR TITLE
Remove upper limit for media-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     },
     "conflict": {
         "jms/serializer": "<0.13",
-        "sonata-project/media-bundle": "<3.0 || >=5.0"
+        "sonata-project/media-bundle": "<3.0"
     },
     "autoload": {
         "psr-4": { "Sonata\\ClassificationBundle\\": "" }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because the build in the master branch is broken.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- removed upper conflict limit for `sonata-project/media-bundle` dependency
```

## Subject

This should fix the build.

