### PR TITLE
using cocur-slugify for tag slugs

### DIFF
--- a/Model/Tag.php
+++ b/Model/Tag.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\ClassificationBundle\Model;
 
+use Cocur\Slugify\Slugify;
+
 abstract class Tag implements TagInterface
 {
     /**
@@ -149,22 +151,7 @@ abstract class Tag implements TagInterface
      */
     public static function slugify($text)
     {
-        // replace non letter or digits by -
-        $text = preg_replace('~[^\\pL\d]+~u', '-', $text);
-
-        // trim
-        $text = trim($text, '-');
-
-        // transliterate
-        if (function_exists('iconv')) {
-            $text = iconv('utf-8', 'us-ascii//TRANSLIT', $text);
-        }
-
-        // lowercase
-        $text = strtolower($text);
-
-        // remove unwanted characters
-        $text = preg_replace('~[^-\w]+~', '', $text);
+        $text = Slugify::create()->slugify($text);
 
         if (empty($text)) {
             return 'n-a';

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     ],
     "require": {
         "php": "^5.3 || ^7.0",
+        "cocur/slugify": "^1.4 || ^2.0",
         "sonata-project/admin-bundle": "^3.0",
         "sonata-project/datagrid-bundle": "^2.2",
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a BC fix

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- incorrect names transliterating for slugs
```
<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

I found a problem with generating slug for russian letters.

Code

```
if (function_exists('iconv')) {
    $text = iconv('utf-8', 'us-ascii//TRANSLIT', $text);
}
```

doesn't work correctly, slugify method returns n-a for all russian tags and it makes a problem with unique constraint.

Actually, we have the cocur/slugify package required in core-bundle, so, we can just use it for generating slugs in classification bundle. It fixes the problem with transliterating.

<!-- Describe your Pull Request content here -->

