### PR TITLE
Fixed missing parameters from parent class

### DIFF
--- a/Admin/ContextAwareAdmin.php
+++ b/Admin/ContextAwareAdmin.php
@@ -68,9 +68,12 @@ abstract class ContextAwareAdmin extends Admin
      */
     public function getPersistentParameters()
     {
-        $parameters = array(
-            'context' => '',
-            'hide_context' => $this->hasRequest() ? (int) $this->getRequest()->get('hide_context', 0) : 0,
+        $parameters = array_merge(
+            parent::getPersistentParameters(),
+            array(
+                'context' => '',
+                'hide_context' => $this->hasRequest() ? (int) $this->getRequest()->get('hide_context', 0) : 0,
+            )
         );
 
         if ($this->getSubject()) {

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Tests\Admin;
+
+use Sonata\ClassificationBundle\Model\ContextManagerInterface;
+
+class AdminTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ContextManagerInterface
+     */
+    private $contextManager;
+
+    public function setUp()
+    {
+        $this->contextManager = $this->getMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+    }
+
+    public function testGetPersistentParametersWithNoExtension()
+    {
+        $expected = array(
+            'context' => '',
+            'hide_context' => 0,
+        );
+
+        $admin = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Admin\ContextAwareAdmin', array(
+            'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin', $this->contextManager,
+        ));
+
+        $this->assertSame($expected, $admin->getPersistentParameters());
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testGetPersistentParametersWithInvalidExtension()
+    {
+        $admin = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Admin\ContextAwareAdmin', array(
+            'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin', $this->contextManager,
+        ));
+
+        $extension = $this->getMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
+        $extension->expects($this->once())->method('getPersistentParameters')->will($this->returnValue(null));
+
+        $admin->addExtension($extension);
+
+        $admin->getPersistentParameters();
+    }
+
+    public function testGetPersistentParametersWithValidExtension()
+    {
+        $expected = array(
+            'tl' => 'de',
+            'abc' => 123,
+            'context' => '',
+            'hide_context' => 0,
+        );
+
+        $extensionParams = array(
+            'tl' => 'de',
+            'abc' => 123,
+        );
+
+        $admin = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Admin\ContextAwareAdmin', array(
+            'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin', $this->contextManager,
+        ));
+
+        $extension = $this->getMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
+        $extension->expects($this->once())->method('getPersistentParameters')->will($this->returnValue($extensionParams));
+
+        $admin->addExtension($extension);
+
+        $this->assertSame($expected, $admin->getPersistentParameters());
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed missing parameters from parent class in `ContextAwareAdmin::getPersistentParameters`
```

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject
`ContextAwareAdmin::getPersistentParameters()` ignored all parameters introduced by extensions in parent `AbstractAdmin` class.
For example `SonataClassificationBundle` entities can be now translated by `SonataTranslationBundle`. `SonataTranslationBundle` introduce `tl` parameter which was ignored.
<!-- Describe your Pull Request content here -->

