### PR TITLE
Fix old Admin class usage

### DIFF
--- a/Admin/ContextAdmin.php
+++ b/Admin/ContextAdmin.php
@@ -11,12 +11,12 @@
 
 namespace Sonata\ClassificationBundle\Admin;
 
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 
-class ContextAdmin extends Admin
+class ContextAdmin extends AbstractAdmin
 {
     /**
      * {@inheritdoc}

--- a/Admin/ContextAwareAdmin.php
+++ b/Admin/ContextAwareAdmin.php
@@ -11,13 +11,13 @@
 
 namespace Sonata\ClassificationBundle\Admin;
 
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\ClassificationBundle\Entity\ContextManager;
 use Sonata\ClassificationBundle\Model\ContextInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 
-abstract class ContextAwareAdmin extends Admin
+abstract class ContextAwareAdmin extends AbstractAdmin
 {
     /**
      * @var ContextManagerInterface

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -11,7 +11,6 @@
 
 namespace Sonata\ClassificationBundle\Tests\Admin;
 
-use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 
 class AdminTest extends \PHPUnit_Framework_TestCase
@@ -31,11 +30,11 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $contextAwareAdmin = $this->getMockBuilder('Sonata\ClassificationBundle\Admin\ContextAwareAdmin')
             ->disableOriginalConstructor()
             ->getMock();
-        $this->assertInstanceOf(AbstractAdmin::class, $contextAwareAdmin);
+        $this->assertInstanceOf('Sonata\AdminBundle\Admin\AbstractAdmin', $contextAwareAdmin);
         $contextAdmin = $this->getMockBuilder('Sonata\ClassificationBundle\Admin\ContextAdmin')
             ->disableOriginalConstructor()
             ->getMock();
-        $this->assertInstanceOf(AbstractAdmin::class, $contextAdmin);
+        $this->assertInstanceOf('Sonata\AdminBundle\Admin\AbstractAdmin', $contextAdmin);
     }
 
     public function testGetPersistentParametersWithNoExtension()

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\ClassificationBundle\Tests\Admin;
 
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 
 class AdminTest extends \PHPUnit_Framework_TestCase
@@ -23,6 +24,18 @@ class AdminTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->contextManager = $this->getMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+    }
+
+    public function testAbstractAdminChildren()
+    {
+        $contextAwareAdmin = $this->getMockBuilder('Sonata\ClassificationBundle\Admin\ContextAwareAdmin')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->assertInstanceOf(AbstractAdmin::class, $contextAwareAdmin);
+        $contextAdmin = $this->getMockBuilder('Sonata\ClassificationBundle\Admin\ContextAdmin')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->assertInstanceOf(AbstractAdmin::class, $contextAdmin);
     }
 
     public function testGetPersistentParametersWithNoExtension()

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^5.3 || ^7.0",
         "cocur/slugify": "^1.4 || ^2.0",
-        "sonata-project/admin-bundle": "^3.0",
+        "sonata-project/admin-bundle": "^3.1",
         "sonata-project/datagrid-bundle": "^2.2",
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
         "symfony/config": "^2.3.9 || ^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch to fix "**PHP Fatal error:  Class 'Sonata\AdminBundle\Admin\Admin' not found**"

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->
```markdown
### Changed
- Use `AbstractAdmin` instead of deprecated `Admin`
```
