### PR TITLE
fix context foreign key constraint

### DIFF
--- a/DependencyInjection/SonataClassificationExtension.php
+++ b/DependencyInjection/SonataClassificationExtension.php
@@ -158,7 +158,7 @@ class SonataClassificationExtension extends Extension
                 array(
                     'name' => 'context',
                     'referencedColumnName' => 'id',
-                    'onDelete' => 'set null',
+                    'onDelete' => 'SET NULL',
                 ),
             ),
             'orphanRemoval' => false,

--- a/DependencyInjection/SonataClassificationExtension.php
+++ b/DependencyInjection/SonataClassificationExtension.php
@@ -158,6 +158,7 @@ class SonataClassificationExtension extends Extension
                 array(
                     'name' => 'context',
                     'referencedColumnName' => 'id',
+                    'onDelete' => 'set null',
                 ),
             ),
             'orphanRemoval' => false,


### PR DESCRIPTION
# Changelog
```markdown
### Fixed
 - Set context to null on delete
```
# Subject
When purging database with doctrine fixtures bundle. You receive error
```
An exception occurred while executing 'DELETE FROM classification__context':                                                                                             
  SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails (`wikium`.`classification__category`, CONSTR  
  AINT `FK_43629B36E25D857E` FOREIGN KEY (`context`) REFERENCES `classification__context` (`id`))
```
