### PR TITLE
fix-context command throws a fatal error.

### DIFF
--- a/Command/FixContextCommand.php
+++ b/Command/FixContextCommand.php
@@ -75,7 +75,7 @@ class FixContextCommand extends ContainerAwareCommand
                 continue;
             }
 
-            $output->writeln(sprintf(' > attach default context to collection: %s (%s)', $tag->getSlug(), $tag->getId()));
+            $output->writeln(sprintf(' > attach default context to collection: %s (%s)', $collection->getSlug(), $collection->getId()));
             $collection->setContext($defaultContext);
 
             $collectionManager->save($collection);


### PR DESCRIPTION
I am targeting this branch, because this issue exists on this branch. 

## Changelog

```markdown
### Changed
- `tag` variable reference inside collection iterator to point to `collection` variable. The incorrect reference was throwing an error when executing sonata:classification:fix-context from the command line.
```

## Subject

Collection iterator references tag variable and should be using collection.