### PR TITLE
French translations + menu icon.

### DIFF
--- a/Resources/config/admin.xml
+++ b/Resources/config/admin.xml
@@ -2,10 +2,11 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
         <parameter key="sonata.classification.admin.groupname">sonata_classification</parameter>
+        <parameter key="sonata.classification.admin.groupicon"><![CDATA[<i class='fa fa-tags'></i>]]></parameter>
     </parameters>
     <services>
         <service id="sonata.classification.admin.category" class="%sonata.classification.admin.category.class%">
-            <tag name="sonata.admin" manager_type="orm" group="%sonata.classification.admin.groupname%" label="label_categories" label_catalogue="%sonata.classification.admin.category.translation_domain%" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="orm" group="%sonata.classification.admin.groupname%" label="label_categories" label_catalogue="%sonata.classification.admin.category.translation_domain%" label_translator_strategy="sonata.admin.label.strategy.underscore" icon="%sonata.classification.admin.groupicon%"/>
             <argument/>
             <argument>%sonata.classification.admin.category.entity%</argument>
             <argument>%sonata.classification.admin.category.controller%</argument>
@@ -21,7 +22,7 @@
             </call>
         </service>
         <service id="sonata.classification.admin.tag" class="%sonata.classification.admin.tag.class%">
-            <tag name="sonata.admin" manager_type="orm" group="%sonata.classification.admin.groupname%" label="label_tags" label_catalogue="%sonata.classification.admin.tag.translation_domain%" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="orm" group="%sonata.classification.admin.groupname%" label="label_tags" label_catalogue="%sonata.classification.admin.tag.translation_domain%" label_translator_strategy="sonata.admin.label.strategy.underscore" icon="%sonata.classification.admin.groupicon%"/>
             <argument/>
             <argument>%sonata.classification.admin.tag.entity%</argument>
             <argument>%sonata.classification.admin.tag.controller%</argument>
@@ -31,7 +32,7 @@
             </call>
         </service>
         <service id="sonata.classification.admin.collection" class="%sonata.classification.admin.collection.class%">
-            <tag name="sonata.admin" manager_type="orm" group="%sonata.classification.admin.groupname%" label="label_collections" label_catalogue="%sonata.classification.admin.collection.translation_domain%" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="orm" group="%sonata.classification.admin.groupname%" label="label_collections" label_catalogue="%sonata.classification.admin.collection.translation_domain%" label_translator_strategy="sonata.admin.label.strategy.underscore" icon="%sonata.classification.admin.groupicon%"/>
             <argument/>
             <argument>%sonata.classification.admin.collection.entity%</argument>
             <argument>%sonata.classification.admin.collection.controller%</argument>
@@ -41,7 +42,7 @@
             </call>
         </service>
         <service id="sonata.classification.admin.context" class="%sonata.classification.admin.context.class%">
-            <tag name="sonata.admin" manager_type="orm" group="%sonata.classification.admin.groupname%" label="label_contexts" label_catalogue="%sonata.classification.admin.context.translation_domain%" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="orm" group="%sonata.classification.admin.groupname%" label="label_contexts" label_catalogue="%sonata.classification.admin.context.translation_domain%" label_translator_strategy="sonata.admin.label.strategy.underscore" icon="%sonata.classification.admin.groupicon%"/>
             <argument/>
             <argument>%sonata.classification.admin.context.entity%</argument>
             <argument>%sonata.classification.admin.context.controller%</argument>

--- a/Resources/config/admin.xml
+++ b/Resources/config/admin.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <parameter key="sonata.classification.admin.groupname">sonata_classification</parameter>
+    </parameters>
     <services>
         <service id="sonata.classification.admin.category" class="%sonata.classification.admin.category.class%">
-            <tag name="sonata.admin" manager_type="orm" group="sonata_classification" label="label_categories" label_catalogue="%sonata.classification.admin.category.translation_domain%" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="orm" group="%sonata.classification.admin.groupname%" label="label_categories" label_catalogue="%sonata.classification.admin.category.translation_domain%" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
             <argument/>
             <argument>%sonata.classification.admin.category.entity%</argument>
             <argument>%sonata.classification.admin.category.controller%</argument>
@@ -18,7 +21,7 @@
             </call>
         </service>
         <service id="sonata.classification.admin.tag" class="%sonata.classification.admin.tag.class%">
-            <tag name="sonata.admin" manager_type="orm" group="sonata_classification" label="label_tags" label_catalogue="%sonata.classification.admin.tag.translation_domain%" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="orm" group="%sonata.classification.admin.groupname%" label="label_tags" label_catalogue="%sonata.classification.admin.tag.translation_domain%" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
             <argument/>
             <argument>%sonata.classification.admin.tag.entity%</argument>
             <argument>%sonata.classification.admin.tag.controller%</argument>
@@ -28,7 +31,7 @@
             </call>
         </service>
         <service id="sonata.classification.admin.collection" class="%sonata.classification.admin.collection.class%">
-            <tag name="sonata.admin" manager_type="orm" group="sonata_classification" label="label_collections" label_catalogue="%sonata.classification.admin.collection.translation_domain%" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="orm" group="%sonata.classification.admin.groupname%" label="label_collections" label_catalogue="%sonata.classification.admin.collection.translation_domain%" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
             <argument/>
             <argument>%sonata.classification.admin.collection.entity%</argument>
             <argument>%sonata.classification.admin.collection.controller%</argument>
@@ -38,7 +41,7 @@
             </call>
         </service>
         <service id="sonata.classification.admin.context" class="%sonata.classification.admin.context.class%">
-            <tag name="sonata.admin" manager_type="orm" group="sonata_classification" label="label_contexts" label_catalogue="%sonata.classification.admin.context.translation_domain%" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="orm" group="%sonata.classification.admin.groupname%" label="label_contexts" label_catalogue="%sonata.classification.admin.context.translation_domain%" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
             <argument/>
             <argument>%sonata.classification.admin.context.entity%</argument>
             <argument>%sonata.classification.admin.context.controller%</argument>

--- a/Resources/translations/SonataClassificationBundle.fr.xliff
+++ b/Resources/translations/SonataClassificationBundle.fr.xliff
@@ -28,7 +28,7 @@
             </trans-unit>
             <trans-unit id="breadcrumb.link_category_tree">
                 <source>breadcrumb.link_category_tree</source>
-                <target>Catégorie</target>
+                <target>Catégories</target>
             </trans-unit>
             <trans-unit id="list.label_name">
                 <source>list.label_name</source>
@@ -68,7 +68,7 @@
             </trans-unit>
             <trans-unit id="breadcrumb.link_tag_list">
                 <source>breadcrumb.link_tag_list</source>
-                <target>Liste des tags</target>
+                <target>Tags</target>
             </trans-unit>
             <trans-unit id="form.label_slug">
                 <source>form.label_slug</source>
@@ -112,11 +112,11 @@
             </trans-unit>
             <trans-unit id="form.label_media">
                 <source>form.label_media</source>
-                <target>Media</target>
+                <target>Média</target>
             </trans-unit>
             <trans-unit id="breadcrumb.link_context_list">
                 <source>breadcrumb.link_context_list</source>
-                <target>Contexts</target>
+                <target>Contextes</target>
             </trans-unit>
             <trans-unit id="list.label_id">
                 <source>list.label_id</source>
@@ -128,7 +128,7 @@
             </trans-unit>
             <trans-unit id="label_contexts">
                 <source>label_contexts</source>
-                <target>Contexts</target>
+                <target>Contextes</target>
             </trans-unit>
             <trans-unit id="form.label_id">
                 <source>form.label_id</source>
@@ -136,11 +136,11 @@
             </trans-unit>
             <trans-unit id="filter.label_context">
                 <source>filter.label_context</source>
-                <target>Context</target>
+                <target>Contexte</target>
             </trans-unit>
             <trans-unit id="list.label_context">
                 <source>list.label_context</source>
-                <target>Context</target>
+                <target>Contexte</target>
             </trans-unit>
             <trans-unit id="tree_catalog_title">
                 <source>tree_catalog_title</source>

--- a/Resources/translations/SonataClassificationBundle.fr.xliff
+++ b/Resources/translations/SonataClassificationBundle.fr.xliff
@@ -168,31 +168,51 @@
             </trans-unit>
             <trans-unit id="form.label_category">
                 <source>form.label_category</source>
-                <target>form.label_category</target>
+                <target>Catégorie</target>
             </trans-unit>
             <trans-unit id="form.label_collection">
                 <source>form.label_collection</source>
-                <target>form.label_collection</target>
+                <target>Collection</target>
             </trans-unit>
             <trans-unit id="form.label_tag">
                 <source>form.label_tag</source>
-                <target>form.label_tag</target>
+                <target>Tag</target>
             </trans-unit>
             <trans-unit id="form.label_title">
                 <source>form.label_title</source>
-                <target>form.label_title</target>
+                <target>Titre</target>
             </trans-unit>
             <trans-unit id="no_collections_found">
                 <source>no_collections_found</source>
-                <target>no_collections_found</target>
+                <target>Aucune collection trouvée</target>
             </trans-unit>
             <trans-unit id="no_categories_found">
                 <source>no_categories_found</source>
-                <target>no_categories_found</target>
+                <target>Aucune catégorie trouvée</target>
             </trans-unit>
             <trans-unit id="no_tags_found">
                 <source>no_tags_found</source>
-                <target>no_tags_found</target>
+                <target>Aucun tag trouvé</target>
+            </trans-unit>
+            <trans-unit id="form.label_context">
+                <source>form.label_context</source>
+                <target>Contexte</target>
+            </trans-unit>
+            <trans-unit id="breadcrumb.link_collection_create">
+                <source>breadcrumb.link_collection_create</source>
+                <target>Ajouter</target>
+            </trans-unit>
+            <trans-unit id="breadcrumb.link_tag_create">
+                <source>breadcrumb.link_tag_create</source>
+                <target>Ajouter</target>
+            </trans-unit>
+            <trans-unit id="breadcrumb.link_category_create">
+                <source>breadcrumb.link_category_create</source>
+                <target>Ajouter</target>
+            </trans-unit>
+            <trans-unit id="breadcrumb.link_context_create">
+                <source>breadcrumb.link_context_create</source>
+                <target>Ajouter</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/SonataClassificationBundle.fr.xliff
+++ b/Resources/translations/SonataClassificationBundle.fr.xliff
@@ -20,11 +20,11 @@
             </trans-unit>
             <trans-unit id="breadcrumb.link_collection_list">
                 <source>breadcrumb.link_collection_list</source>
-                <target>Liste des collections</target>
+                <target>Collections</target>
             </trans-unit>
             <trans-unit id="breadcrumb.link_category_list">
                 <source>breadcrumb.link_category_list</source>
-                <target>Liste des catégories</target>
+                <target>Catégories</target>
             </trans-unit>
             <trans-unit id="breadcrumb.link_category_tree">
                 <source>breadcrumb.link_category_tree</source>


### PR DESCRIPTION
I am targetting this branch, because it will not break BC.

## Changelog

```markdown
### Added
- Menu icon (fa-tags).
- Fix bad / missing translations in french.
```

## Subject
- choose `fa-tags` instead of `fa-bars` used everywhere for this Bundle (in the documentation at least),
- harmonize breadcrumbs `_list` with simply the name of the entity instead of using "List of XXX", because it is the most common usage in other bundles (idem for `_create`'s breadcrumbs).