### PR TITLE
Sf3 compatibility

### DIFF
--- a/Admin/CategoryAdmin.php
+++ b/Admin/CategoryAdmin.php
@@ -15,9 +15,11 @@ use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Route\RouteCollection;
+use Symfony\Component\Validator\Constraints\Valid;
 
 class CategoryAdmin extends ContextAwareAdmin
 {
+    // NEXT_MAJOR: remove this override
     protected $formOptions = array(
         'cascade_validation' => true,
     );
@@ -28,6 +30,26 @@ class CategoryAdmin extends ContextAwareAdmin
     public function configureRoutes(RouteCollection $routes)
     {
         $routes->add('tree', 'tree');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFormBuilder()
+    {
+        // NEXT_MAJOR: set constraints unconditionally
+        if (isset($this->formOptions['cascade_validation'])) {
+            unset($this->formOptions['cascade_validation']);
+            $this->formOptions['constraints'][] = new Valid();
+        } else {
+            @trigger_error(<<<'EOT'
+Unsetting cascade_validation is deprecated since 3.x, and will give an error in 4.0.
+Override getFormBuilder() and remove the "Valid" constraint instead.
+EOT
+            , E_USER_DEPRECATED);
+        }
+
+        return parent::getFormBuilder();
     }
 
     /**

--- a/Admin/CollectionAdmin.php
+++ b/Admin/CollectionAdmin.php
@@ -14,12 +14,34 @@ namespace Sonata\ClassificationBundle\Admin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
+use Symfony\Component\Validator\Constraints\Valid;
 
 class CollectionAdmin extends ContextAwareAdmin
 {
+    // NEXT_MAJOR: remove this override
     protected $formOptions = array(
         'cascade_validation' => true,
     );
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFormBuilder()
+    {
+        // NEXT_MAJOR: set constraints unconditionally
+        if (isset($this->formOptions['cascade_validation'])) {
+            unset($this->formOptions['cascade_validation']);
+            $this->formOptions['constraints'][] = new Valid();
+        } else {
+            @trigger_error(<<<'EOT'
+Unsetting cascade_validation is deprecated since 3.x, and will give an error in 4.0.
+Override getFormBuilder() and remove the "Valid" constraint instead.
+EOT
+            , E_USER_DEPRECATED);
+        }
+
+        return parent::getFormBuilder();
+    }
 
     /**
      * {@inheritdoc}

--- a/Form/Type/CategorySelectorType.php
+++ b/Form/Type/CategorySelectorType.php
@@ -17,6 +17,7 @@ use Sonata\CoreBundle\Model\ManagerInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
 use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -40,9 +41,16 @@ class CategorySelectorType extends AbstractType
     }
 
     /**
+     * NEXT_MAJOR: Remove method, when bumping requirements to SF 2.7+.
+     *
      * {@inheritdoc}
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
     {
         $that = $this;
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,12 @@
 UPGRADE 3.x
 ===========
 
+### Deep validation
+
+In `CategoryAdmin` and `CollectionAdmin`,
+disabling deep validation by unsetting the `cascade_validation` option is now deprecated,
+and should be done by overriding `getFormBuilder` instead.
+
 ### Tests
 
 All files under the ``Tests`` directory are now correctly handled as internal test classes. 


### PR DESCRIPTION
I am targetting this branch, because this is BC.

Closes #249 

## Changelog

```markdown
### Fixed
- Symfony 3 compatibility was improved
```

## Subject

This PR fixes issues raised in #249 , but in a backwards-compatible manner.
