### PR TITLE
Replace deprecated BlockBundle classes

### DIFF
--- a/Block/Service/AbstractClassificationBlockService.php
+++ b/Block/Service/AbstractClassificationBlockService.php
@@ -14,7 +14,7 @@ namespace Sonata\ClassificationBundle\Block\Service;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Block\BaseBlockService;
+use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\ClassificationBundle\Model\ContextInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
@@ -23,7 +23,7 @@ use Symfony\Component\Form\FormBuilder;
 /**
  * @author Christian Gripp <mail@core23.de>
  */
-abstract class AbstractClassificationBlockService extends BaseBlockService
+abstract class AbstractClassificationBlockService extends AbstractAdminBlockService
 {
     /**
      * @var ContextManagerInterface

--- a/Tests/Block/Service/AbstractCategoriesBlockServiceTest.php
+++ b/Tests/Block/Service/AbstractCategoriesBlockServiceTest.php
@@ -11,8 +11,8 @@
 
 namespace Sonata\ClassificationBundle\Tests\Block\Service;
 
-use Sonata\BlockBundle\Tests\Block\AbstractBlockServiceTest;
-use Sonata\BlockBundle\Tests\Block\Service\FakeTemplating;
+use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
+use Sonata\BlockBundle\Test\FakeTemplating;
 use Sonata\ClassificationBundle\Admin\CategoryAdmin;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
@@ -20,7 +20,7 @@ use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 /**
  * @author Christian Gripp <mail@core23.de>
  */
-final class AbstractCategoriesBlockServiceTest extends AbstractBlockServiceTest
+final class AbstractCategoriesBlockServiceTest extends AbstractBlockServiceTestCase
 {
     /**
      * @var ContextManagerInterface

--- a/Tests/Block/Service/AbstractCollectionsBlockServiceTest.php
+++ b/Tests/Block/Service/AbstractCollectionsBlockServiceTest.php
@@ -11,8 +11,8 @@
 
 namespace Sonata\ClassificationBundle\Tests\Block\Service;
 
-use Sonata\BlockBundle\Tests\Block\AbstractBlockServiceTest;
-use Sonata\BlockBundle\Tests\Block\Service\FakeTemplating;
+use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
+use Sonata\BlockBundle\Test\FakeTemplating;
 use Sonata\ClassificationBundle\Admin\CollectionAdmin;
 use Sonata\ClassificationBundle\Model\CollectionManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
@@ -20,7 +20,7 @@ use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 /**
  * @author Christian Gripp <mail@core23.de>
  */
-final class AbstractCollectionsBlockServiceTest extends AbstractBlockServiceTest
+final class AbstractCollectionsBlockServiceTest extends AbstractBlockServiceTestCase
 {
     /**
      * @var ContextManagerInterface

--- a/Tests/Block/Service/AbstractTagsBlockServiceTest.php
+++ b/Tests/Block/Service/AbstractTagsBlockServiceTest.php
@@ -12,15 +12,15 @@
 namespace Sonata\ClassificationBundle\Tests\Block\Service;
 
 use Sonata\AdminBundle\Tests\Fixtures\Admin\TagAdmin;
-use Sonata\BlockBundle\Tests\Block\AbstractBlockServiceTest;
-use Sonata\BlockBundle\Tests\Block\Service\FakeTemplating;
+use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
+use Sonata\BlockBundle\Test\FakeTemplating;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 use Sonata\ClassificationBundle\Model\TagManagerInterface;
 
 /**
  * @author Christian Gripp <mail@core23.de>
  */
-final class AbstractTagsBlockServiceTest extends AbstractBlockServiceTest
+final class AbstractTagsBlockServiceTest extends AbstractBlockServiceTestCase
 {
     /**
      * @var ContextManagerInterface

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "friendsofsymfony/rest-bundle": "^1.1 || ^2.0",
         "jms/serializer-bundle": "^0.13 || ^1.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
-        "sonata-project/block-bundle": "^3.0",
+        "sonata-project/block-bundle": "^3.2",
         "sonata-project/media-bundle": "^3.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0"
     },


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Increase block-bundle dependency to ^3.2

### Fixed
- Fix deprecated `AbstractBlockServiceTest`, `FakeTemplating`, `BaseBlockService` usage

```

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

<!-- Describe your Pull Request content here -->
Deprecation was introduced in BlockBundle 3.1 and 3.2. Fixed according to [UPGRADE-3.x.md](https://github.com/sonata-project/SonataBlockBundle/blob/3.x/UPGRADE-3.x.md).