### PR TITLE
Fix vertical centering of buttons within a navbar in list/tree selector

### DIFF
--- a/Resources/views/CategoryAdmin/list_tab_menu.html.twig
+++ b/Resources/views/CategoryAdmin/list_tab_menu.html.twig
@@ -1,11 +1,9 @@
 {{ knp_menu_render(admin.sidemenu(action), {'currentClass' : 'active'}, 'list') }}
-<p>
-    <div class="btn-group">
-        <a type="button" class="btn {% if mode == 'list' %}btn-info active{% else %}btn-default{% endif %}" href="{{ admin.generateUrl('list', { 'filter': { 'context': { 'value': current_category is defined ? current_category.context.id|default('') : '' }}}) }}">
-            <i class="fa fa-list"></i> {{ 'classification.list_mode'|trans({}, 'SonataClassificationBundle') }}
-        </a>
-        <a type="button" class="btn {% if mode == 'tree' %}btn-info active{% else %}btn-default{% endif %}" href="{{ admin.generateUrl('tree') }}">
-            <i class="fa fa-sitemap"></i> {{ 'classification.tree_mode'|trans({}, 'SonataClassificationBundle') }}
-        </a>
-    </div>
-</p>
+<div class="btn-group">
+    <a type="button" class="navbar-btn btn {% if mode == 'list' %}btn-info active{% else %}btn-default{% endif %}" href="{{ admin.generateUrl('list', { 'filter': { 'context': { 'value': current_category is defined ? current_category.context.id|default('') : '' }}}) }}">
+        <i class="fa fa-list"></i> {{ 'classification.list_mode'|trans({}, 'SonataClassificationBundle') }}
+    </a>
+    <a type="button" class="navbar-btn btn {% if mode == 'tree' %}btn-info active{% else %}btn-default{% endif %}" href="{{ admin.generateUrl('tree') }}">
+        <i class="fa fa-sitemap"></i> {{ 'classification.tree_mode'|trans({}, 'SonataClassificationBundle') }}
+    </a>
+</div>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is BC fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix vertical centering of buttons within a navbar in list/tree selector

```
## Subject

<!-- Describe your Pull Request content here -->
Replace DIV in P which was not HTML compliant by adding .navbar-btn class to buttons. P element expects phrasing content not the flow content https://www.w3.org/TR/html5/grouping-content.html#the-p-element

From bootstrap comments:
> Vertically center a button within a navbar (when *not* in a form).
> .navbar-btn {

And the proof that it still works :)
![after](https://cloud.githubusercontent.com/assets/1571340/21359685/5081e548-c6dd-11e6-8f52-f4a3f1b21fe5.png)
