### PR TITLE
Fix entity class names in Advanced Configuration doc

### DIFF
--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -9,27 +9,27 @@ Advanced Configuration
     .. code-block:: yaml
 
         sonata_classification:
-        class:
-            tag:          Application\Sonata\ClassificationBundle\Entity\Tag
-            category:     Application\Sonata\ClassificationBundle\Entity\Category
-            collection:   Application\Sonata\ClassificationBundle\Entity\Collection
-            media:        Application\Sonata\MediaBundle\Entity\Collection
-            context:      Application\Sonata\ClassificationBundle\Entity\Collection
+            class:
+                tag:          Application\Sonata\ClassificationBundle\Entity\Tag
+                category:     Application\Sonata\ClassificationBundle\Entity\Category
+                collection:   Application\Sonata\ClassificationBundle\Entity\Collection
+                media:        Application\Sonata\MediaBundle\Entity\Media
+                context:      Application\Sonata\ClassificationBundle\Entity\Context
 
-        admin:
-            tag:
-                class:        Sonata\ClassificationBundle\Admin\TagAdmin
-                controller:   SonataAdminBundle:CRUD
-                translation:  SonataClassificationBundle
-            category:
-                class:        Sonata\ClassificationBundle\Admin\CategoryAdmin
-                controller:   SonataClassificationBundle:CategoryAdmin
-                translation:  SonataClassificationBundle
-            collection:
-                class:        Sonata\ClassificationBundle\Admin\CollectionAdmin
-                controller:   SonataAdminBundle:CRUD
-                translation:  SonataClassificationBundle
-            context:
-                class:        Sonata\ClassificationBundle\Admin\ContextAdmin
-                controller:   SonataAdminBundle:CRUD
-                translation:  SonataClassificationBundle
+            admin:
+                tag:
+                    class:        Sonata\ClassificationBundle\Admin\TagAdmin
+                    controller:   SonataAdminBundle:CRUD
+                    translation:  SonataClassificationBundle
+                category:
+                    class:        Sonata\ClassificationBundle\Admin\CategoryAdmin
+                    controller:   SonataClassificationBundle:CategoryAdmin
+                    translation:  SonataClassificationBundle
+                collection:
+                    class:        Sonata\ClassificationBundle\Admin\CollectionAdmin
+                    controller:   SonataAdminBundle:CRUD
+                    translation:  SonataClassificationBundle
+                context:
+                    class:        Sonata\ClassificationBundle\Admin\ContextAdmin
+                    controller:   SonataAdminBundle:CRUD
+                    translation:  SonataClassificationBundle


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is BC documentation fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- Fix entity class names in Advanced Configuration doc
```

## Subject
Continuation of #136, #173.
Update context and media entity classes. There was some copy paste typo.
Improve indentation.