### PR TITLE
Fix the category tree view in case the category list is empty

### DIFF
--- a/Controller/CategoryAdminController.php
+++ b/Controller/CategoryAdminController.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * Page Admin Controller.
+ * Category Admin Controller.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
@@ -67,6 +67,7 @@ class CategoryAdminController extends Controller
     {
         $categoryManager = $this->get('sonata.classification.manager.category');
 
+        $mainCategory = false;
         $currentContext = false;
         if ($context = $request->get('context')) {
             $currentContext = $this->get('sonata.classification.manager.context')->find($context);
@@ -74,7 +75,7 @@ class CategoryAdminController extends Controller
 
         $rootCategories = $categoryManager->getRootCategories(false);
 
-        if (!$currentContext) {
+        if (!$currentContext && !empty($rootCategories)) {
             $mainCategory = current($rootCategories);
             $currentContext = $mainCategory->getContext();
         } else {

--- a/Resources/views/CategoryAdmin/tree.html.twig
+++ b/Resources/views/CategoryAdmin/tree.html.twig
@@ -51,7 +51,7 @@ file that was distributed with this source code.
             <div class="box-header">
                 <h1 class="box-title">
                     {{ admin.trans('tree_catalog_title', {}, admin.translationdomain) }}
-                    {% if not app.request.get('hide_context') %}
+                    {% if not app.request.get('hide_context') and current_context is not empty %}
                         <div class="btn-group">
                             <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                                 <strong class="text-info">{{ current_context.name }}</strong> <span class="caret"></span>
@@ -75,7 +75,11 @@ file that was distributed with this source code.
                 </h1>
             </div>
             <div class="box-content">
-                {{ tree.navigate_child([main_category], admin, true, 0) }}
+                {% if main_category is empty %}
+                    {{ tree.navigate_child([], admin, true, 0) }}
+                {% else %}
+                    {{ tree.navigate_child([main_category], admin, true, 0) }}
+                {% endif %}
             </div>
         </div>
     </div>

--- a/Tests/Controller/CategoryAdminControllerTest.php
+++ b/Tests/Controller/CategoryAdminControllerTest.php
@@ -1,0 +1,444 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Tests;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\ClassificationBundle\Controller\CategoryAdminController;
+use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
+use Sonata\ClassificationBundle\Model\ContextManagerInterface;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Security\Csrf\CsrfToken;
+
+/**
+ * @author Dariusz Markowicz <dmarkowicz77@gmail.com>
+ */
+class CategoryAdminControllerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Request
+     */
+    private $request;
+
+    /**
+     * @var AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @var array
+     */
+    private $parameters;
+
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * @var string
+     */
+    private $template;
+
+    /**
+     * @var CsrfProviderInterface
+     */
+    private $csrfProvider;
+
+    /**
+     * @var CategoryAdminController
+     */
+    private $controller;
+
+    /**
+     * @var CategoryManagerInterface
+     */
+    private $categoryManager;
+
+    /**
+     * @var ContextManagerInterface
+     */
+    private $contextManager;
+
+    /**
+     * Based on Sonata\AdminBundle\Tests\Controller\CRUDControllerTest.
+     */
+    protected function setUp()
+    {
+        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+
+        $this->request = new Request();
+        $this->pool = new Pool($this->container, 'title', 'logo.png');
+        $this->pool->setAdminServiceIds(array('foo.admin'));
+        $this->request->attributes->set('_sonata_admin', 'foo.admin');
+        $this->parameters = array();
+        $this->template = '';
+
+        // php 5.3 BC
+        $params = &$this->parameters;
+        $template = &$this->template;
+
+        $templating = $this->getMock(
+            'Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine',
+            array(),
+            array($this->container, array())
+        );
+
+        $templating->expects($this->any())
+            ->method('renderResponse')
+            ->will($this->returnCallback(function (
+                $view,
+                array $parameters = array(),
+                Response $response = null
+            ) use (
+                &$params,
+                &$template
+            ) {
+                $template = $view;
+
+                if (null === $response) {
+                    $response = new Response();
+                }
+
+                $params = $parameters;
+
+                return $response;
+            }));
+
+        // php 5.3 BC
+        $pool = $this->pool;
+        $request = $this->request;
+
+        $twig = $this->getMockBuilder('Twig_Environment')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $twigRenderer = $this->getMock('Symfony\Bridge\Twig\Form\TwigRendererInterface');
+
+        $formExtension = new FormExtension($twigRenderer);
+
+        $twig->expects($this->any())
+            ->method('getExtension')
+            ->will($this->returnCallback(function ($name) use ($formExtension) {
+                switch ($name) {
+                    case 'form':
+                    case 'Symfony\Bridge\Twig\Extension\FormExtension':
+                        return $formExtension;
+                }
+            }));
+
+        $twig->expects($this->any())
+            ->method('getRuntime')
+            ->will($this->returnCallback(function ($name) use ($twigRenderer) {
+                switch ($name) {
+                    case 'Symfony\Bridge\Twig\Form\TwigRenderer':
+                        if (method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
+                            return $twigRenderer;
+                        }
+
+                        throw new \Twig_Error_Runtime('This runtime exists when Symony >= 3.2.');
+                }
+            }));
+
+        // Prefer Symfony 2.x interfaces
+        if (interface_exists('Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface')) {
+            $this->csrfProvider = $this->getMockBuilder(
+                'Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface'
+            )
+                ->getMock();
+
+            $this->csrfProvider->expects($this->any())
+                ->method('generateCsrfToken')
+                ->will($this->returnCallback(function ($intention) {
+                    return 'csrf-token-123_'.$intention;
+                }));
+
+            $this->csrfProvider->expects($this->any())
+                ->method('isCsrfTokenValid')
+                ->will($this->returnCallback(function ($intention, $token) {
+                    if ($token == 'csrf-token-123_'.$intention) {
+                        return true;
+                    }
+
+                    return false;
+                }));
+        } else {
+            $this->csrfProvider = $this->getMockBuilder(
+                'Symfony\Component\Security\Csrf\CsrfTokenManagerInterface'
+            )
+                ->getMock();
+
+            $this->csrfProvider->expects($this->any())
+                ->method('getToken')
+                ->will($this->returnCallback(function ($intention) {
+                    return new CsrfToken($intention, 'csrf-token-123_'.$intention);
+                }));
+
+            $this->csrfProvider->expects($this->any())
+                ->method('isTokenValid')
+                ->will($this->returnCallback(function (CsrfToken $token) {
+                    if ($token->getValue() == 'csrf-token-123_'.$token->getId()) {
+                        return true;
+                    }
+
+                    return false;
+                }));
+        }
+
+        // php 5.3 BC
+        $csrfProvider = $this->csrfProvider;
+
+        $this->admin = $this->getMockBuilder('Sonata\ClassificationBundle\Admin\CategoryAdmin')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $admin = $this->admin;
+
+        $this->categoryManager = $this->getMockBuilder('Sonata\ClassificationBundle\Entity\CategoryManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $categoryManager = $this->categoryManager;
+
+        $this->contextManager = $this->getMockBuilder('Sonata\ClassificationBundle\Entity\ContextManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $contextManager = $this->contextManager;
+
+        $this->container->expects($this->any())
+            ->method('get')
+            ->will($this->returnCallback(function ($id) use (
+                $pool,
+                $admin,
+                $request,
+                $templating,
+                $twig,
+                $csrfProvider,
+                $categoryManager,
+                $contextManager
+            ) {
+                switch ($id) {
+                    case 'sonata.admin.pool':
+                        return $pool;
+                    case 'request':
+                        return $request;
+                    case 'foo.admin':
+                        return $admin;
+                    case 'templating':
+                        return $templating;
+                    case 'twig':
+                        return $twig;
+                    case 'form.csrf_provider':
+                    case 'security.csrf.token_manager':
+                        return $csrfProvider;
+                    case 'sonata.classification.manager.category':
+                        return $categoryManager;
+                    case 'sonata.classification.manager.context':
+                        return $contextManager;
+                }
+            }));
+
+        // php 5.3
+        $tthis = $this;
+
+        $this->container->expects($this->any())
+            ->method('has')
+            ->will($this->returnCallback(function ($id) use ($tthis) {
+                if ($id == 'form.csrf_provider' && Kernel::MAJOR_VERSION == 2 && $tthis->getCsrfProvider() !== null) {
+                    return true;
+                }
+
+                if ($id == 'security.csrf.token_manager' && Kernel::MAJOR_VERSION >= 3 && $tthis->getCsrfProvider() !== null) {
+                    return true;
+                }
+
+                if ($id == 'templating') {
+                    return true;
+                }
+
+                return false;
+            }));
+
+        $this->admin->expects($this->any())
+            ->method('generateUrl')
+            ->will(
+                $this->returnCallback(
+                    function ($name, array $parameters = array(), $absolute = false) {
+                        $result = $name;
+                        if (!empty($parameters)) {
+                            $result .= '?'.http_build_query($parameters);
+                        }
+
+                        return $result;
+                    }
+                )
+            );
+
+        $this->controller = new CategoryAdminController();
+        $this->controller->setContainer($this->container);
+    }
+
+    protected function tearDown()
+    {
+        $this->controller = null;
+    }
+
+    public function testListActionWithoutFilter()
+    {
+        $this->request->query->set('hide_context', '0');
+
+        $result = $this->controller->listAction($this->request);
+        $this->assertInstanceOf(
+            'Symfony\Component\HttpFoundation\RedirectResponse', $result);
+        $this->assertSame('tree?hide_context=0', $result->getTargetUrl());
+    }
+
+    /**
+     * @dataProvider listActionData
+     */
+    public function testListAction($context)
+    {
+        $this->request->query->set('_list_mode', 'list');
+        $this->request->query->set('filter', 'filter[context][value]='.($context ? $context : ''));
+
+        $datagrid = $this->getMock('Sonata\AdminBundle\Datagrid\DatagridInterface');
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $form->expects($this->once())
+             ->method('createView')
+             ->will($this->returnValue($this->getMock('Symfony\Component\Form\FormView')));
+
+        $this->admin->expects($this->once())
+            ->method('getDatagrid')
+            ->will($this->returnValue($datagrid));
+
+        $datagrid->expects($this->once())
+            ->method('getForm')
+            ->will($this->returnValue($form));
+
+        $this->admin->expects($this->any())
+            ->method('getPersistentParameter')
+            ->will($this->returnValue($context));
+
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response',
+            $this->controller->listAction($this->request));
+    }
+
+    public function listActionData()
+    {
+        return array(
+            'context' => array('default'),
+            'no context' => array(false),
+        );
+    }
+
+    /**
+     * @dataProvider treeActionData
+     */
+    public function testTreeAction($context, $categories)
+    {
+        $datagrid = $this->getMock('Sonata\AdminBundle\Datagrid\DatagridInterface');
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $form->expects($this->once())
+            ->method('createView')
+            ->will($this->returnValue($this->getMock('Symfony\Component\Form\FormView')));
+
+        $this->admin->expects($this->once())
+            ->method('getDatagrid')
+            ->will($this->returnValue($datagrid));
+
+        $datagrid->expects($this->once())
+            ->method('getForm')
+            ->will($this->returnValue($form));
+
+        $this->admin->expects($this->any())
+            ->method('getPersistentParameter')
+            ->will($this->returnValue('default'));
+
+        if ($context) {
+            $contextMock = $this->getContextMock($context);
+            $this->request->query->set('context', $contextMock->getId());
+            $this->contextManager->expects($this->any())
+                ->method('find')
+                ->will($this->returnValue($contextMock));
+        } else {
+            $this->request->query->remove('context');
+            $this->contextManager->expects($this->any())
+                ->method('find')
+                ->will($this->returnValue(false));
+        }
+
+        $categoriesMock = array();
+        foreach ($categories as $category) {
+            $categoryMock = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Category');
+            $categoryMock->setName($category[0]);
+            if ($category[1]) {
+                $categoryMock->setContext($this->getContextMock($category[1]));
+            }
+            $categoryMock->setEnabled(true);
+            array_push($categoriesMock, $categoryMock);
+        }
+
+        $this->categoryManager->expects($this->any())
+            ->method('getRootCategories')
+            ->will($this->returnValue($categoriesMock));
+
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response',
+            $this->controller->treeAction($this->request));
+    }
+
+    public function treeActionData()
+    {
+        return array(
+            'context and no categories' => array('default', array()),
+            'no context and no categories' => array(false, array()),
+            'context and categories' => array('default', array(
+                array('First Category', 'other'),
+                array('Second Category', 'default'),
+            )),
+            'no context and categories' => array(false, array(
+                array('First Category', 'other'),
+                array('Second Category', 'default'),
+            )),
+        );
+    }
+
+    public function getCsrfProvider()
+    {
+        return $this->csrfProvider;
+    }
+
+    private function getContextMock($id)
+    {
+        $contextMock = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Context');
+        $contextMock->expects($this->any())->method('getId')->will($this->returnValue($id));
+        $contextMock->setName($id);
+        $contextMock->setEnabled(true);
+
+        return $contextMock;
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #159
Closes #180

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Unit tests for `CategoryAdminController`

### Fixed
- Fix the category tree view in case the category list is empty
```

## Subject
Continuation of #160 but rewritten from scratch. Added a check to prevent `Call to a member function getContext() on boolean` error in `treeAction()`. This is a case when category base is empty.
Unit tests are based on `CRUDControllerTest` and fully cover `CategoryAdminController`.