### PR TITLE
fixed fosrest 2.0 support

### DIFF
--- a/Controller/Api/CategoryController.php
+++ b/Controller/Api/CategoryController.php
@@ -69,7 +69,7 @@ class CategoryController
      * @QueryParam(name="enabled", requirements="0|1", nullable=true, strict=true, description="Enabled/Disabled categories filter")
      * @QueryParam(name="context", requirements="\S+", nullable=true, strict=true, description="Context of categories")
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param ParamFetcherInterface $paramFetcher
      *
@@ -100,7 +100,7 @@ class CategoryController
      *  }
      * )
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param $id
      *

--- a/Controller/Api/CollectionController.php
+++ b/Controller/Api/CollectionController.php
@@ -68,7 +68,7 @@ class CollectionController
      * @QueryParam(name="count", requirements="\d+", default="10", description="Number of collections by page")
      * @QueryParam(name="enabled", requirements="0|1", nullable=true, strict=true, description="Enabled/Disabled collections filter")
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param ParamFetcherInterface $paramFetcher
      *
@@ -99,7 +99,7 @@ class CollectionController
      *  }
      * )
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param $id
      *

--- a/Controller/Api/ContextController.php
+++ b/Controller/Api/ContextController.php
@@ -68,7 +68,7 @@ class ContextController
      * @QueryParam(name="count", requirements="\d+", default="10", description="Number of contexts by page")
      * @QueryParam(name="enabled", requirements="0|1", nullable=true, strict=true, description="Enabled/Disabled contexts filter")
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param ParamFetcherInterface $paramFetcher
      *
@@ -99,7 +99,7 @@ class ContextController
      *  }
      * )
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param $id
      *

--- a/Controller/Api/TagController.php
+++ b/Controller/Api/TagController.php
@@ -68,7 +68,7 @@ class TagController
      * @QueryParam(name="count", requirements="\d+", default="10", description="Number of tags by page")
      * @QueryParam(name="enabled", requirements="0|1", nullable=true, strict=true, description="Enabled/Disabled tags filter")
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param ParamFetcherInterface $paramFetcher
      *
@@ -99,7 +99,7 @@ class TagController
      *  }
      * )
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param $id
      *


### PR DESCRIPTION
Somehow this one slipped away in fosrest 2.0 support. Like in sonata-user and sonata-media, serializationGroups need to be arrays and not strings to support both fos-rest 1 and 2.

## Changelog

```markdown
### Changed
- Changed api controller serializationGroups from strings to arrays
```
## Subject

This should complete fos-rest >= 2.0 support for this bundle too. Its bc-compatible.