### PR TITLE
Fix typos in Service unit tests

### DIFF
--- a/Tests/Block/Service/AbstractCategoriesBlockServiceTest.php
+++ b/Tests/Block/Service/AbstractCategoriesBlockServiceTest.php
@@ -65,10 +65,10 @@ final class AbstractCategoriesBlockServiceTest extends AbstractBlockServiceTestC
 
     public function testLoad()
     {
-        $category = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CategoryInterfacer')
+        $category = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CategoryInterface')
             ->setMethods(array('getId'))
             ->disableOriginalConstructor()
-            ->getMock();
+            ->getMockForAbstractClass();
         $category->expects($this->any())->method('getId')->will($this->returnValue(23));
 
         $this->categoryManager->expects($this->any())
@@ -93,10 +93,10 @@ final class AbstractCategoriesBlockServiceTest extends AbstractBlockServiceTestC
 
     public function testPrePersist()
     {
-        $category = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CategoryInterfacer')
+        $category = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CategoryInterface')
             ->setMethods(array('getId'))
             ->disableOriginalConstructor()
-            ->getMock();
+            ->getMockForAbstractClass();
         $category->expects($this->any())->method('getId')->will($this->returnValue(23));
 
         $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
@@ -116,10 +116,10 @@ final class AbstractCategoriesBlockServiceTest extends AbstractBlockServiceTestC
 
     public function testPreUpdate()
     {
-        $category = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CategoryInterfacer')
+        $category = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CategoryInterface')
             ->setMethods(array('getId'))
             ->disableOriginalConstructor()
-            ->getMock();
+            ->getMockForAbstractClass();
         $category->expects($this->any())->method('getId')->will($this->returnValue(23));
 
         $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');

--- a/Tests/Block/Service/AbstractCollectionsBlockServiceTest.php
+++ b/Tests/Block/Service/AbstractCollectionsBlockServiceTest.php
@@ -65,10 +65,10 @@ final class AbstractCollectionsBlockServiceTest extends AbstractBlockServiceTest
 
     public function testLoad()
     {
-        $collection = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CollectionInterfacer')
+        $collection = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CollectionInterface')
             ->setMethods(array('getId'))
             ->disableOriginalConstructor()
-            ->getMock();
+            ->getMockForAbstractClass();
         $collection->expects($this->any())->method('getId')->will($this->returnValue(23));
 
         $this->collectionManager->expects($this->any())
@@ -93,10 +93,10 @@ final class AbstractCollectionsBlockServiceTest extends AbstractBlockServiceTest
 
     public function testPrePersist()
     {
-        $collection = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CollectionInterfacer')
+        $collection = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CollectionInterface')
             ->setMethods(array('getId'))
             ->disableOriginalConstructor()
-            ->getMock();
+            ->getMockForAbstractClass();
         $collection->expects($this->any())->method('getId')->will($this->returnValue(23));
 
         $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
@@ -116,10 +116,10 @@ final class AbstractCollectionsBlockServiceTest extends AbstractBlockServiceTest
 
     public function testPreUpdate()
     {
-        $collection = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CollectionInterfacer')
+        $collection = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CollectionInterface')
             ->setMethods(array('getId'))
             ->disableOriginalConstructor()
-            ->getMock();
+            ->getMockForAbstractClass();
         $collection->expects($this->any())->method('getId')->will($this->returnValue(23));
 
         $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');

--- a/Tests/Block/Service/AbstractTagsBlockServiceTest.php
+++ b/Tests/Block/Service/AbstractTagsBlockServiceTest.php
@@ -65,10 +65,10 @@ final class AbstractTagsBlockServiceTest extends AbstractBlockServiceTestCase
 
     public function testLoad()
     {
-        $tag = $this->getMockBuilder('Sonata\ClassificationBundle\Model\TagInterfacer')
+        $tag = $this->getMockBuilder('Sonata\ClassificationBundle\Model\TagInterface')
             ->setMethods(array('getId'))
             ->disableOriginalConstructor()
-            ->getMock();
+            ->getMockForAbstractClass();
         $tag->expects($this->any())->method('getId')->will($this->returnValue(23));
 
         $this->tagManager->expects($this->any())
@@ -93,10 +93,10 @@ final class AbstractTagsBlockServiceTest extends AbstractBlockServiceTestCase
 
     public function testPrePersist()
     {
-        $tag = $this->getMockBuilder('Sonata\ClassificationBundle\Model\TagInterfacer')
+        $tag = $this->getMockBuilder('Sonata\ClassificationBundle\Model\TagInterface')
             ->setMethods(array('getId'))
             ->disableOriginalConstructor()
-            ->getMock();
+            ->getMockForAbstractClass();
         $tag->expects($this->any())->method('getId')->will($this->returnValue(23));
 
         $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
@@ -116,10 +116,10 @@ final class AbstractTagsBlockServiceTest extends AbstractBlockServiceTestCase
 
     public function testPreUpdate()
     {
-        $tag = $this->getMockBuilder('Sonata\ClassificationBundle\Model\TagInterfacer')
+        $tag = $this->getMockBuilder('Sonata\ClassificationBundle\Model\TagInterface')
             ->setMethods(array('getId'))
             ->disableOriginalConstructor()
-            ->getMock();
+            ->getMockForAbstractClass();
         $tag->expects($this->any())->method('getId')->will($this->returnValue(23));
 
         $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed typo in Service unit tests
```

## Subject
Change "Interfacer" to "Interface" in interface names and adapt mock. Not sure if typo or hack. IMHO looks better now.
<!-- Describe your Pull Request content here -->
