### PR TITLE
Add context field validation in tag/collection forms

### DIFF
--- a/Resources/config/validation.xml
+++ b/Resources/config/validation.xml
@@ -19,6 +19,9 @@
                 <option name="max">32</option>
             </constraint>
         </property>
+        <property name="context">
+            <constraint name="NotBlank"/>
+        </property>
     </class>
     <class name="Sonata\ClassificationBundle\Model\Collection">
         <property name="name">
@@ -28,6 +31,9 @@
                 <option name="min">2</option>
                 <option name="max">32</option>
             </constraint>
+        </property>
+        <property name="context">
+            <constraint name="NotBlank"/>
         </property>
     </class>
     <class name="Sonata\ClassificationBundle\Model\Context">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- context fields validation in tag/collection create forms, which prevents creating objects
  with empty context from UI
```

## Subject
Current create forms allow user to create objects with empty context, which is a bug (`sonata:classification:fix-context` command try to repair such situations).

This PR
- add `required` attribute and `NotBlank` constraint to tag/collection forms to show nice message to user.
- prevent creating tag/collection with no context from UI
