### PR TITLE
remove useless class comments

### DIFF
--- a/Controller/Api/CategoryController.php
+++ b/Controller/Api/CategoryController.php
@@ -28,8 +28,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
- * Class CategoryController.
- *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
 class CategoryController

--- a/Controller/Api/CategoryController.php
+++ b/Controller/Api/CategoryController.php
@@ -43,8 +43,6 @@ class CategoryController
     protected $formFactory;
 
     /**
-     * Constructor.
-     *
      * @param CategoryManagerInterface $categoryManager
      * @param FormFactoryInterface     $formFactory
      */

--- a/Controller/Api/CollectionController.php
+++ b/Controller/Api/CollectionController.php
@@ -28,8 +28,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
- * Class CollectionController.
- *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
 class CollectionController

--- a/Controller/Api/CollectionController.php
+++ b/Controller/Api/CollectionController.php
@@ -43,8 +43,6 @@ class CollectionController
     protected $formFactory;
 
     /**
-     * Constructor.
-     *
      * @param CollectionManagerInterface $collectionManager
      * @param FormFactoryInterface       $formFactory
      */

--- a/Controller/Api/ContextController.php
+++ b/Controller/Api/ContextController.php
@@ -28,8 +28,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
- * Class ContextController.
- *
  * @author Thomas Rabaix <thomas.rabaix@gmail.com>
  */
 class ContextController

--- a/Controller/Api/ContextController.php
+++ b/Controller/Api/ContextController.php
@@ -43,8 +43,6 @@ class ContextController
     protected $formFactory;
 
     /**
-     * Constructor.
-     *
      * @param ContextManagerInterface $contextManager
      * @param FormFactoryInterface    $formFactory
      */

--- a/Controller/Api/TagController.php
+++ b/Controller/Api/TagController.php
@@ -43,8 +43,6 @@ class TagController
     protected $formFactory;
 
     /**
-     * Constructor.
-     *
      * @param TagManagerInterface  $tagManager
      * @param FormFactoryInterface $formFactory
      */

--- a/Controller/Api/TagController.php
+++ b/Controller/Api/TagController.php
@@ -28,8 +28,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
- * Class TagController.
- *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
 class TagController

--- a/Tests/Controller/Api/CategoryControllerTest.php
+++ b/Tests/Controller/Api/CategoryControllerTest.php
@@ -15,8 +15,6 @@ use Sonata\ClassificationBundle\Controller\Api\CategoryController;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * Class CategoryControllerTest.
- *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
 class CategoryControllerTest extends \PHPUnit_Framework_TestCase

--- a/Tests/Controller/Api/CollectionControllerTest.php
+++ b/Tests/Controller/Api/CollectionControllerTest.php
@@ -15,8 +15,6 @@ use Sonata\ClassificationBundle\Controller\Api\CollectionController;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * Class CollectionControllerTest.
- *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
 class CollectionControllerTest extends \PHPUnit_Framework_TestCase

--- a/Tests/Controller/Api/ContextControllerTest.php
+++ b/Tests/Controller/Api/ContextControllerTest.php
@@ -15,8 +15,6 @@ use Sonata\ClassificationBundle\Controller\Api\ContextController;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * Class ContextControllerTest.
- *
  * @author Thomas Rabaix <thomas.rabaix@gmail.com>
  */
 class ContextControllerTest extends \PHPUnit_Framework_TestCase

--- a/Tests/Controller/Api/TagControllerTest.php
+++ b/Tests/Controller/Api/TagControllerTest.php
@@ -15,8 +15,6 @@ use Sonata\ClassificationBundle\Controller\Api\TagController;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * Class TagControllerTest.
- *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
 class TagControllerTest extends \PHPUnit_Framework_TestCase

--- a/Tests/Entity/CategoryManagerTest.php
+++ b/Tests/Entity/CategoryManagerTest.php
@@ -14,9 +14,6 @@ namespace Sonata\ClassificationBundle\Tests\Entity;
 use Sonata\ClassificationBundle\Entity\CategoryManager;
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
 
-/**
- * Class CategoryManagerTest.
- */
 class CategoryManagerTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetPager()

--- a/Tests/Entity/CollectionManagerTest.php
+++ b/Tests/Entity/CollectionManagerTest.php
@@ -14,9 +14,6 @@ namespace Sonata\ClassificationBundle\Tests\Entity;
 use Sonata\ClassificationBundle\Entity\CollectionManager;
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
 
-/**
- * Class CollectionManagerTest.
- */
 class CollectionManagerTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetPager()

--- a/Tests/Entity/ContextManagerTest.php
+++ b/Tests/Entity/ContextManagerTest.php
@@ -14,9 +14,6 @@ namespace Sonata\ClassificationBundle\Tests\Entity;
 use Sonata\ClassificationBundle\Entity\ContextManager;
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
 
-/**
- * Class ContextManagerTest.
- */
 class ContextManagerTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetPager()

--- a/Tests/Entity/TagManagerTest.php
+++ b/Tests/Entity/TagManagerTest.php
@@ -14,9 +14,6 @@ namespace Sonata\ClassificationBundle\Tests\Entity;
 use Sonata\ClassificationBundle\Entity\TagManager;
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
 
-/**
- * Class TagManagerTest.
- */
 class TagManagerTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetPager()


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.
