### PR TITLE
Add model unit tests

### DIFF
--- a/Tests/Model/CategoryTest.php
+++ b/Tests/Model/CategoryTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Tests\Model;
+
+use Sonata\ClassificationBundle\Model\Category;
+use Sonata\ClassificationBundle\Model\ContextInterface;
+use Sonata\MediaBundle\Model\MediaInterface;
+
+/**
+ * @author Dariusz Markowicz <dmarkowicz77@gmail.com>
+ */
+class CategoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSetterGetter()
+    {
+        $time = new \DateTime();
+
+        /** @var ContextInterface $context */
+        $context = $this->getMockBuilder('Sonata\ClassificationBundle\Model\ContextInterface')->getMock();
+
+        /** @var MediaInterface $media */
+        $media = $this->getMockBuilder('Sonata\MediaBundle\Model\MediaInterface')->getMock();
+
+        /** @var Category $category */
+        $category = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Category');
+        $category->setName('Hello World');
+        $category->setEnabled(true);
+        $category->setDescription('My description');
+        $category->setCreatedAt($time);
+        $category->setUpdatedAt($time);
+        $category->setPosition(2);
+        $category->setMedia($media);
+        $category->setContext($context);
+
+        $this->assertEquals('Hello World', $category->getName());
+        $this->assertEquals('Hello World', $category->__toString());
+        $this->assertEquals('hello-world', $category->getSlug());
+        $this->assertTrue($category->getEnabled());
+        $this->assertEquals('My description', $category->getDescription());
+        $this->assertEquals($time, $category->getCreatedAt());
+        $this->assertEquals($time, $category->getUpdatedAt());
+        $this->assertEquals(2, $category->getPosition());
+        $this->assertEquals($media, $category->getMedia());
+        $this->assertEquals($context, $category->getContext());
+
+        $category->setName('');
+        $this->assertEquals('n-a', $category->getSlug());
+        $this->assertEquals('n/a', $category->__toString());
+
+        $category->setName('Привет мир');
+        $this->assertEquals('privet-mir', $category->getSlug());
+        $this->assertEquals('Привет мир', $category->__toString());
+
+        $category->setSlug('Custom Slug');
+        $this->assertEquals('custom-slug', $category->getSlug());
+    }
+
+    public function testParent()
+    {
+        /** @var Category $parent */
+        $parent = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Category');
+
+        /** @var Category $category */
+        $category = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Category');
+        $category->setParent($parent);
+        $this->assertEquals($parent, $category->getParent());
+        $this->assertCount(1, $parent->getChildren());
+    }
+
+    public function testChildren()
+    {
+        /** @var Category $cat1 */
+        $cat1 = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Category');
+        /** @var Category $cat2 */
+        $cat2 = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Category');
+        /** @var Category $cat3 */
+        $cat3 = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Category');
+
+        /** @var ContextInterface $context */
+        $context = $this->getMockBuilder('Sonata\ClassificationBundle\Model\ContextInterface')->getMock();
+
+        /** @var Category $category */
+        $category = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Category');
+        $category->setContext($context);
+        $this->assertFalse($category->hasChildren());
+
+        $category->addChild($cat1);
+        $category->addChild($cat2);
+        $category->addChild($cat3);
+        $this->assertEquals($context, $cat1->getContext()); // child context set to parent
+        $this->assertEquals($category, $cat1->getParent());
+        $this->assertTrue($category->hasChildren());
+        $this->assertCount(3, $category->getChildren());
+
+        // Category::removeChild implementation use getId() which is not a part of interface nor model, skipping
+
+        // No type hint in interface so assume basic array.
+        $category->setChildren(array());
+        $this->assertCount(0, $category->getChildren());
+        $category->setChildren(array($cat1, $cat2, $cat3));
+        $this->assertCount(3, $category->getChildren());
+    }
+
+    public function testPrePersist()
+    {
+        /** @var Category $category */
+        $category = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Category');
+        $category->prePersist();
+
+        $this->assertInstanceOf('\DateTime', $category->getCreatedAt());
+        $this->assertInstanceOf('\DateTime', $category->getUpdatedAt());
+    }
+
+    public function testPreUpdate()
+    {
+        /** @var Category $category */
+        $category = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Category');
+        $category->preUpdate();
+
+        $this->assertInstanceOf('\DateTime', $category->getUpdatedAt());
+    }
+}

--- a/Tests/Model/CollectionTest.php
+++ b/Tests/Model/CollectionTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Tests\Model;
+
+use Sonata\ClassificationBundle\Model\Collection;
+use Sonata\ClassificationBundle\Model\ContextInterface;
+use Sonata\MediaBundle\Model\MediaInterface;
+
+/**
+ * @author Dariusz Markowicz <dmarkowicz77@gmail.com>
+ */
+class CollectionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSetterGetter()
+    {
+        $time = new \DateTime();
+
+        /** @var ContextInterface $context */
+        $context = $this->getMockBuilder('Sonata\ClassificationBundle\Model\ContextInterface')->getMock();
+
+        /** @var MediaInterface $media */
+        $media = $this->getMockBuilder('Sonata\MediaBundle\Model\MediaInterface')->getMock();
+
+        /** @var Collection $collection */
+        $collection = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Collection');
+        $collection->setName('Hello World');
+        $collection->setCreatedAt($time);
+        $collection->setUpdatedAt($time);
+        $collection->setEnabled(true);
+        $collection->setDescription('My description');
+        $collection->setMedia($media);
+        $collection->setContext($context);
+
+        $this->assertEquals('Hello World', $collection->getName());
+        $this->assertEquals('Hello World', $collection->__toString());
+        $this->assertEquals('hello-world', $collection->getSlug());
+        $this->assertEquals($time, $collection->getCreatedAt());
+        $this->assertEquals($time, $collection->getUpdatedAt());
+        $this->assertTrue($collection->getEnabled());
+        $this->assertEquals('My description', $collection->getDescription());
+        $this->assertEquals($media, $collection->getMedia());
+        $this->assertEquals($context, $collection->getContext());
+
+        $collection->setName('');
+        $this->assertEquals('n-a', $collection->getSlug());
+        $this->assertEquals('n/a', $collection->__toString());
+
+        $collection->setName('Привет мир');
+        $this->assertEquals('privet-mir', $collection->getSlug());
+        $this->assertEquals('Привет мир', $collection->__toString());
+
+        $collection->setSlug('Custom Slug');
+        $this->assertEquals('custom-slug', $collection->getSlug());
+    }
+
+    public function testPrePersist()
+    {
+        /** @var Collection $collection */
+        $collection = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Collection');
+        $collection->prePersist();
+
+        $this->assertInstanceOf('\DateTime', $collection->getCreatedAt());
+        $this->assertInstanceOf('\DateTime', $collection->getUpdatedAt());
+    }
+
+    public function testPreUpdate()
+    {
+        /** @var Collection $collection */
+        $collection = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Collection');
+        $collection->preUpdate();
+
+        $this->assertInstanceOf('\DateTime', $collection->getUpdatedAt());
+    }
+}

--- a/Tests/Model/ContextTest.php
+++ b/Tests/Model/ContextTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Tests\Model;
+
+use Sonata\ClassificationBundle\Model\Context;
+
+/**
+ * @author Dariusz Markowicz <dmarkowicz77@gmail.com>
+ */
+class ContextTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSetterGetter()
+    {
+        $time = new \DateTime();
+
+        /** @var Context $context */
+        $context = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Context');
+        // id is an int in ContextInterface and Context but used as string in implementation
+        // see ContextInterface::DEFAULT_CONTEXT
+        $context->setId(2);
+        $context->setName('Hello World');
+        $context->setCreatedAt($time);
+        $context->setUpdatedAt($time);
+        $context->setEnabled(true);
+
+        $this->assertEquals('Hello World', $context->getName());
+        $this->assertEquals('Hello World', $context->__toString());
+        $this->assertEquals($time, $context->getCreatedAt());
+        $this->assertEquals($time, $context->getUpdatedAt());
+        $this->assertTrue($context->getEnabled());
+
+        $context->setName('');
+        $this->assertEquals('n/a', $context->__toString());
+    }
+
+    public function testPreUpdate()
+    {
+        /** @var Context $context */
+        $context = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Context');
+        $context->preUpdate();
+
+        $this->assertInstanceOf('\DateTime', $context->getUpdatedAt());
+    }
+}

--- a/Tests/Model/TagTest.php
+++ b/Tests/Model/TagTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Tests\Model;
+
+use Sonata\ClassificationBundle\Model\ContextInterface;
+use Sonata\ClassificationBundle\Model\Tag;
+
+/**
+ * @author Dariusz Markowicz <dmarkowicz77@gmail.com>
+ */
+class TagTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSetterGetter()
+    {
+        $time = new \DateTime();
+
+        /** @var ContextInterface $context */
+        $context = $this->getMockBuilder('Sonata\ClassificationBundle\Model\ContextInterface')->getMock();
+
+        /** @var Tag $tag */
+        $tag = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Tag');
+        $tag->setName('Hello World');
+        $tag->setCreatedAt($time);
+        $tag->setUpdatedAt($time);
+        $tag->setEnabled(true);
+        $tag->setContext($context);
+
+        $this->assertEquals('Hello World', $tag->getName());
+        $this->assertEquals('Hello World', $tag->__toString());
+        $this->assertEquals('hello-world', $tag->getSlug());
+        $this->assertEquals($time, $tag->getCreatedAt());
+        $this->assertEquals($time, $tag->getUpdatedAt());
+        $this->assertTrue($tag->getEnabled());
+        $this->assertEquals($context, $tag->getContext());
+
+        $tag->setName('');
+        $this->assertEquals('n-a', $tag->getSlug());
+        $this->assertEquals('n/a', $tag->__toString());
+
+        $tag->setName('Привет мир');
+        $this->assertEquals('privet-mir', $tag->getSlug());
+        $this->assertEquals('Привет мир', $tag->__toString());
+
+        $tag->setSlug('Custom Slug');
+        $this->assertEquals('custom-slug', $tag->getSlug());
+    }
+
+    public function testPreUpdate()
+    {
+        /** @var Tag $tag */
+        $tag = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Tag');
+        $tag->preUpdate();
+
+        $this->assertInstanceOf('\DateTime', $tag->getUpdatedAt());
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is BC, only tests.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #130

## Changelog
Not needed

## Subject
Added unit tests for models. Closes #130 because tests that issue too.

I found a problem with `Category::removeChild` while writing these tests. This function use `$childToDelete->getId()` which is not a part of `CategoryInterface` (see #152). For now, I just added a comment in the code.
<!-- Describe your Pull Request content here -->
