### PR TITLE
Symfony3.*: use ArrayChoiceList instead of deprecated SimpleChoiceList

### DIFF
--- a/Form/Type/CategorySelectorType.php
+++ b/Form/Type/CategorySelectorType.php
@@ -52,7 +52,7 @@ class CategorySelectorType extends AbstractType
     }
 
     /**
-     * NEXT_MAJOR: replace usage of deprecated SimpleChoiceList
+     * NEXT_MAJOR: replace usage of deprecated SimpleChoiceList.
      *
      * {@inheritdoc}
      */

--- a/Form/Type/CategorySelectorType.php
+++ b/Form/Type/CategorySelectorType.php
@@ -15,6 +15,7 @@ use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\CoreBundle\Model\ManagerInterface;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -50,6 +51,11 @@ class CategorySelectorType extends AbstractType
         $this->configureOptions($resolver);
     }
 
+    /**
+     * NEXT_MAJOR: replace usage of deprecated SimpleChoiceList
+     *
+     * {@inheritdoc}
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $that = $this;
@@ -58,7 +64,11 @@ class CategorySelectorType extends AbstractType
             'context' => null,
             'category' => null,
             'choice_list' => function (Options $opts, $previousValue) use ($that) {
-                return new SimpleChoiceList($that->getChoices($opts));
+                if (class_exists('Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList')) {    // BC with Symfony 2.*
+                    return new SimpleChoiceList($that->getChoices($opts));
+                }
+
+                return new ArrayChoiceList($that->getChoices($opts));
             },
         ));
     }

--- a/Tests/Form/Type/CategorySelectorTypeTest.php
+++ b/Tests/Form/Type/CategorySelectorTypeTest.php
@@ -1,11 +1,6 @@
 <?php
 
-namespace Sonata\ClassificationBundle\Tests\Form\Type;
-
-use Sonata\ClassificationBundle\Form\Type\CategorySelectorType;
-use Symfony\Component\OptionsResolver\OptionsResolver;
-
-/**
+/*
  * This file is part of the Sonata Project package.
  *
  * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -13,6 +8,12 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+namespace Sonata\ClassificationBundle\Tests\Form\Type;
+
+use Sonata\ClassificationBundle\Form\Type\CategorySelectorType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
 class CategorySelectorTypeTest extends \PHPUnit_Framework_TestCase
 {
     public function testConfigureOptions()

--- a/Tests/Form/Type/CategorySelectorTypeTest.php
+++ b/Tests/Form/Type/CategorySelectorTypeTest.php
@@ -17,7 +17,7 @@ class CategorySelectorTypeTest extends \PHPUnit_Framework_TestCase
 {
     public function testConfigureOptions()
     {
-        $manager = $this->createMock('Sonata\CoreBundle\Model\ManagerInterface');
+        $manager = $this->getMock('Sonata\CoreBundle\Model\ManagerInterface');
         $categorySelectorType = new CategorySelectorType($manager);
         $categorySelectorType->configureOptions(new OptionsResolver());
     }

--- a/Tests/Form/Type/CategorySelectorTypeTest.php
+++ b/Tests/Form/Type/CategorySelectorTypeTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Sonata\ClassificationBundle\Tests\Form\Type;
+
+use Sonata\ClassificationBundle\Form\Type\CategorySelectorType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class CategorySelectorTypeTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConfigureOptions()
+    {
+        $manager = $this->createMock('Sonata\CoreBundle\Model\ManagerInterface');
+        $categorySelectorType = new CategorySelectorType($manager);
+        $categorySelectorType->configureOptions(new OptionsResolver());
+    }
+}

--- a/Tests/Form/Type/CategorySelectorTypeTest.php
+++ b/Tests/Form/Type/CategorySelectorTypeTest.php
@@ -5,6 +5,14 @@ namespace Sonata\ClassificationBundle\Tests\Form\Type;
 use Sonata\ClassificationBundle\Form\Type\CategorySelectorType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 class CategorySelectorTypeTest extends \PHPUnit_Framework_TestCase
 {
     public function testConfigureOptions()


### PR DESCRIPTION
I am targetting this branch, because PR isn't break BC.

## Changelog
```markdown
### Fixed
- Fix deprecated `SimpleChoiceList`
```