### PR TITLE
Symfony3.*: use ArrayChoiceList instead of deprecated SimpleChoiceList

### DIFF
--- a/Form/Type/CategorySelectorType.php
+++ b/Form/Type/CategorySelectorType.php
@@ -15,6 +15,7 @@ use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\CoreBundle\Model\ManagerInterface;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -50,6 +51,11 @@ class CategorySelectorType extends AbstractType
         $this->configureOptions($resolver);
     }
 
+    /**
+     * NEXT_MAJOR: replace usage of deprecated SimpleChoiceList.
+     *
+     * {@inheritdoc}
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $that = $this;
@@ -58,7 +64,11 @@ class CategorySelectorType extends AbstractType
             'context' => null,
             'category' => null,
             'choice_list' => function (Options $opts, $previousValue) use ($that) {
-                return new SimpleChoiceList($that->getChoices($opts));
+                if (class_exists('Symfony\Component\Form\ChoiceList\ArrayChoiceList')) {
+                    return new ArrayChoiceList($that->getChoices($opts));
+                }
+
+                return new SimpleChoiceList($that->getChoices($opts));      // BC with Symfony 2.*
             },
         ));
     }

--- a/Tests/Form/Type/CategorySelectorTypeTest.php
+++ b/Tests/Form/Type/CategorySelectorTypeTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Tests\Form\Type;
+
+use Sonata\ClassificationBundle\Form\Type\CategorySelectorType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class CategorySelectorTypeTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConfigureOptions()
+    {
+        $manager = $this->getMock('Sonata\CoreBundle\Model\ManagerInterface');
+        $categorySelectorType = new CategorySelectorType($manager);
+        $categorySelectorType->configureOptions(new OptionsResolver());
+    }
+}


### PR DESCRIPTION
I am targetting this branch, because PR isn't break BC.

Changelog

```markdown
### Fixed
- Fix deprecated `SimpleChoiceList`
```