### PR TITLE
Fixed build

### DIFF
--- a/Tests/Entity/CategoryManagerTest.php
+++ b/Tests/Entity/CategoryManagerTest.php
@@ -21,6 +21,7 @@ class CategoryManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getCategoryManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array()));
                 $qb->expects($self->exactly(1))->method('andWhere')->withConsecutive(
                     array($self->equalTo('c.context = :context'))
                 );
@@ -34,8 +35,7 @@ class CategoryManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getCategoryManager(function ($qb) use ($self) {
-                /* @var $self \PHPUnit_Framework_TestCase */
-                /* @var $qb \PHPUnit_Framework_MockObject_InvocationMocker */
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array()));
                 $qb->expects($self->exactly(2))->method('andWhere')->withConsecutive(
                     array($self->equalTo('c.context = :context')),
                     array($self->equalTo('c.enabled = :enabled'))
@@ -53,8 +53,7 @@ class CategoryManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getCategoryManager(function ($qb) use ($self) {
-                /* @var $self \PHPUnit_Framework_TestCase */
-                /* @var $qb \PHPUnit_Framework_MockObject_InvocationMocker */
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array()));
                 $qb->expects($self->exactly(2))->method('andWhere')->withConsecutive(
                     array($self->equalTo('c.context = :context')),
                     array($self->equalTo('c.enabled = :enabled'))

--- a/Tests/Entity/CollectionManagerTest.php
+++ b/Tests/Entity/CollectionManagerTest.php
@@ -21,6 +21,7 @@ class CollectionManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getCollectionManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array()));
                 $qb->expects($self->never())->method('andWhere');
                 $qb->expects($self->once())->method('setParameters')->with(array());
             })
@@ -32,6 +33,7 @@ class CollectionManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getCollectionManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array()));
                 $qb->expects($self->once())->method('andWhere')->with($self->equalTo('c.enabled = :enabled'));
                 $qb->expects($self->once())->method('setParameters')->with(array('enabled' => true));
             })
@@ -45,6 +47,7 @@ class CollectionManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getCollectionManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array()));
                 $qb->expects($self->once())->method('andWhere')->with($self->equalTo('c.enabled = :enabled'));
                 $qb->expects($self->once())->method('setParameters')->with(array('enabled' => false));
             })

--- a/Tests/Entity/ContextManagerTest.php
+++ b/Tests/Entity/ContextManagerTest.php
@@ -21,6 +21,7 @@ class ContextManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getContextManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array()));
                 $qb->expects($self->never())->method('andWhere');
                 $qb->expects($self->once())->method('setParameters')->with(array());
             })
@@ -32,6 +33,7 @@ class ContextManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getContextManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array()));
                 $qb->expects($self->once())->method('andWhere')->with($self->equalTo('c.enabled = :enabled'));
                 $qb->expects($self->once())->method('setParameters')->with(array('enabled' => true));
             })
@@ -45,6 +47,7 @@ class ContextManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getContextManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array()));
                 $qb->expects($self->once())->method('andWhere')->with($self->equalTo('c.enabled = :enabled'));
                 $qb->expects($self->once())->method('setParameters')->with(array('enabled' => false));
             })

--- a/Tests/Entity/TagManagerTest.php
+++ b/Tests/Entity/TagManagerTest.php
@@ -21,6 +21,7 @@ class TagManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getTagManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array()));
                 $qb->expects($self->never())->method('andWhere');
                 $qb->expects($self->once())->method('setParameters')->with(array());
             })
@@ -32,6 +33,7 @@ class TagManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getTagManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array()));
                 $qb->expects($self->once())->method('andWhere')->with($self->equalTo('t.enabled = :enabled'));
                 $qb->expects($self->once())->method('setParameters')->with(array('enabled' => true));
             })
@@ -45,6 +47,7 @@ class TagManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getTagManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array()));
                 $qb->expects($self->once())->method('andWhere')->with($self->equalTo('t.enabled = :enabled'));
                 $qb->expects($self->once())->method('setParameters')->with(array('enabled' => false));
             })

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^5.3 || ^7.0",
         "cocur/slugify": "^1.4 || ^2.0",
         "sonata-project/admin-bundle": "^3.1",
-        "sonata-project/datagrid-bundle": "^2.2",
+        "sonata-project/datagrid-bundle": "^2.2.1",
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
         "symfony/config": "^2.3.9 || ^3.0",
         "symfony/console": "^2.3 || ^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because I am only changing tests.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #277 

## Subject

<!-- Describe your Pull Request content here -->

Datagrid bundle implements getRootAliases which is not mocked on other bundles, so it makes build fail. This PR fixes this.