### PR TITLE
Symfony3.*: use choice_loader instead of deprecated choice_list

### DIFF
--- a/Form/ChoiceList/CategoryChoiceLoader.php
+++ b/Form/ChoiceList/CategoryChoiceLoader.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Form\ChoiceList;
+
+use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
+use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
+
+final class CategoryChoiceLoader implements ChoiceLoaderInterface
+{
+    /**
+     * The loaded choice list.
+     *
+     * @var ArrayChoiceList
+     */
+    private $choiceList;
+
+    /**
+     * @var array
+     */
+    private $choices;
+
+    /**
+     * @param array $choices
+     */
+    public function __construct($choices)
+    {
+        $this->choices = $choices;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadChoiceList($value = null)
+    {
+        if (null !== $this->choiceList) {
+            return $this->choiceList;
+        }
+
+        return $this->choiceList = new ArrayChoiceList($this->choices, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadChoicesForValues(array $values, $value = null)
+    {
+        if (empty($values)) {
+            return array();
+        }
+
+        return $this->loadChoiceList($value)->getChoicesForValues($values);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadValuesForChoices(array $choices, $value = null)
+    {
+        if (empty($choices)) {
+            return array();
+        }
+
+        return $this->loadChoiceList($value)->getValuesForChoices($choices);
+    }
+}

--- a/Form/Type/CategorySelectorType.php
+++ b/Form/Type/CategorySelectorType.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\ClassificationBundle\Form\Type;
 
+use Sonata\ClassificationBundle\Form\ChoiceList\CategoryChoiceLoader;
 use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\CoreBundle\Model\ManagerInterface;
@@ -50,15 +51,31 @@ class CategorySelectorType extends AbstractType
         $this->configureOptions($resolver);
     }
 
+    /**
+     * NEXT_MAJOR: replace usage of deprecated 'choice_list' option, when bumping requirements to SF 2.7+.
+     *
+     * {@inheritdoc}
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $that = $this;
 
+        if (!class_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')) {
+            $resolver->setDefaults(array(
+                'context' => null,
+                'category' => null,
+                'choice_list' => function (Options $opts, $previousValue) use ($that) {
+                    return new SimpleChoiceList($that->getChoices($opts));
+                },
+            ));
+
+            return;
+        }
         $resolver->setDefaults(array(
             'context' => null,
             'category' => null,
-            'choice_list' => function (Options $opts, $previousValue) use ($that) {
-                return new SimpleChoiceList($that->getChoices($opts));
+            'choice_loader' => function (Options $opts, $previousValue) use ($that) {
+                return new CategoryChoiceLoader(array_flip($that->getChoices($opts)));
             },
         ));
     }

--- a/Tests/Form/ChoiceList/CategoryChoiceLoaderTest.php
+++ b/Tests/Form/ChoiceList/CategoryChoiceLoaderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Form\ChoiceList;
+
+use Sonata\ClassificationBundle\Form\ChoiceList\CategoryChoiceLoader;
+
+/**
+ * @author Anton Zlotnikov <exp.razor@gmail.com>
+ */
+class CategoryChoiceLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        if (!interface_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')) {
+            $this->markTestSkipped('Test only available for >= SF3.0');
+        }
+    }
+
+    public function testLoadChoiceList()
+    {
+        $choices = array(
+            1 => 'foo',
+            2 => 'bar',
+        );
+
+        $categoryLoader = new CategoryChoiceLoader(array_flip($choices));
+
+        $this->assertSame($choices, $categoryLoader->loadChoiceList()->getOriginalKeys());
+    }
+
+    public function testLoadChoicesForValues()
+    {
+        $choices = array(
+            1 => 'foo',
+            2 => 'bar',
+        );
+
+        $categoryLoader = new CategoryChoiceLoader(array_flip($choices));
+
+        $this->assertSame(array_keys($choices), $categoryLoader->loadChoicesForValues(array(1, 2, 3)));
+    }
+
+    public function testLoadValuesForChoices()
+    {
+        $choices = array(
+            1 => 'foo',
+            2 => 'bar',
+        );
+
+        $categoryLoader = new CategoryChoiceLoader(array_flip($choices));
+
+        //due to string typecast of values inside of ArrayChoiceList
+        $expectedChoices = array(
+            'foo' => '1',
+            'bar' => '2',
+        );
+
+        $choices['3'] = 'extra';
+
+        $this->assertSame($expectedChoices, $categoryLoader->loadValuesForChoices(array_flip($choices)));
+    }
+}

--- a/Tests/Form/Type/CategorySelectorTypeTest.php
+++ b/Tests/Form/Type/CategorySelectorTypeTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Tests\Form\Type;
+
+use Sonata\ClassificationBundle\Form\Type\CategorySelectorType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @author Anton Zlotnikov <exp.razor@gmail.com>
+ */
+class CategorySelectorTypeTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConfigureOptions()
+    {
+        $manager = $this->getMock('Sonata\CoreBundle\Model\ManagerInterface');
+        $categorySelectorType = new CategorySelectorType($manager);
+        $optionsResolver = new OptionsResolver();
+        $categorySelectorType->configureOptions($optionsResolver);
+        //unable to get defined options on SF2.3
+        if (!method_exists($optionsResolver, 'getDefinedOptions')) {
+            return;
+        }
+        $definedOptions = $optionsResolver->getDefinedOptions();
+        $this->assertContains('category', $definedOptions);
+        $this->assertContains('context', $definedOptions);
+        if (class_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')) {
+            $this->assertContains('choice_loader', $definedOptions);
+            $this->assertNotContains('choice_list', $definedOptions);
+        } else {
+            $this->assertContains('choice_list', $definedOptions);
+            $this->assertNotContains('choice_loader', $definedOptions);
+        }
+    }
+}


### PR DESCRIPTION
I am targetting this branch, because PR isn't break BC.
## Changelog
```markdown

### Fixed
- Fix usage of deprecated `choice_list` option for >=SF2.7
