### PR TITLE
Symfony3.*: use ArrayChoiceList instead of deprecated SimpleChoiceList

### DIFF
--- a/Form/Type/CategorySelectorType.php
+++ b/Form/Type/CategorySelectorType.php
@@ -16,7 +16,7 @@ use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\CoreBundle\Model\ManagerInterface;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
+use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -65,7 +65,7 @@ class CategorySelectorType extends AbstractType
                 'context' => null,
                 'category' => null,
                 'choice_list' => function (Options $opts, $previousValue) use ($that) {
-                    return new SimpleChoiceList($that->getChoices($opts));
+                    return new ArrayChoiceList($that->getChoices($opts));
                 },
             ));
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because The Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList class has been removed in favor of Symfony\Component\Form\ChoiceList\ArrayChoiceList in symfony 3

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed the using of deprecated SimpleChoiceList
```

## Subject

use ArrayChoiceList instead of deprecated SimpleChoiceList
