### PR TITLE
Make classification blocks more robust

### DIFF
--- a/Block/Service/AbstractCategoriesBlockService.php
+++ b/Block/Service/AbstractCategoriesBlockService.php
@@ -158,12 +158,12 @@ abstract class AbstractCategoriesBlockService extends AbstractClassificationBloc
     }
 
     /**
-     * @param CategoryInterface|int  $id
-     * @param CategoryInterface|null $default
+     * @param CategoryInterface|int $id
+     * @param mixed                 $default
      *
      * @return CategoryInterface
      */
-    final protected function getCategory($id, CategoryInterface $default = null)
+    final protected function getCategory($id, $default = null)
     {
         if ($id instanceof CategoryInterface) {
             return $id;
@@ -173,7 +173,11 @@ abstract class AbstractCategoriesBlockService extends AbstractClassificationBloc
             return $this->categoryManager->find($id);
         }
 
-        return $default;
+        if ($default instanceof CategoryInterface) {
+            return $default;
+        }
+
+        return null;
     }
 
     /**

--- a/Block/Service/AbstractCollectionsBlockService.php
+++ b/Block/Service/AbstractCollectionsBlockService.php
@@ -159,12 +159,12 @@ abstract class AbstractCollectionsBlockService extends AbstractClassificationBlo
     }
 
     /**
-     * @param CollectionInterface|int  $id
-     * @param CollectionInterface|null $default
+     * @param CollectionInterface|int $id
+     * @param mixed                   $default
      *
-     * @return CollectionInterface
+     * @return CollectionInterface|null
      */
-    final protected function getCollection($id, CollectionInterface $default = null)
+    final protected function getCollection($id, $default = null)
     {
         if ($id instanceof CollectionInterface) {
             return $id;
@@ -174,7 +174,11 @@ abstract class AbstractCollectionsBlockService extends AbstractClassificationBlo
             return $this->collectionManager->find($id);
         }
 
-        return $default;
+        if ($default instanceof CollectionInterface) {
+            return $default;
+        }
+
+        return null;
     }
 
     /**

--- a/Block/Service/AbstractTagsBlockService.php
+++ b/Block/Service/AbstractTagsBlockService.php
@@ -167,11 +167,11 @@ abstract class AbstractTagsBlockService extends AbstractClassificationBlockServi
 
     /**
      * @param TagInterface|int $id
-     * @param TagInterface     $default
+     * @param mixed            $default
      *
-     * @return TagInterface
+     * @return TagInterface|null
      */
-    final protected function getTag($id, TagInterface $default = null)
+    final protected function getTag($id, $default = null)
     {
         if ($id instanceof TagInterface) {
             return $id;
@@ -181,7 +181,11 @@ abstract class AbstractTagsBlockService extends AbstractClassificationBlockServi
             return $this->tagManager->find($id);
         }
 
-        return $default;
+        if ($default instanceof TagInterface) {
+            return $default;
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a BC bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Allow false value for category in `AbstractCategoriesBlockService`
 - Allow false value for collection in `AbstractCollectionsBlockService`
 - Allow false value for tag in `AbstractTagsBlockService`
```

## Subject

There is a problem in all `Abstract*TYPE*BlockService`s. E.g. when using the `AbstractCategoriesBlockService` without any special block setting the following exception occurs:

```
Argument 2 passed to Sonata\ClassificationBundle\Block\Service\AbstractCategoriesBlockService::get*() 
must implement interface Sonata\ClassificationBundle\Model\CategoryInterface, boolean given
```

The default option is a boolean value which causes a method mismatch. This PR changes the method signature of the (final) methods to allow any value (e.g. false) and checks if this a valid object for the block service.
