### PR TITLE
Fix bug with class_exists instead of interface_exists in CategorySele…

### DIFF
--- a/Form/Type/CategorySelectorType.php
+++ b/Form/Type/CategorySelectorType.php
@@ -60,7 +60,7 @@ class CategorySelectorType extends AbstractType
     {
         $that = $this;
 
-        if (!class_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')) {
+        if (!interface_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')) {
             $resolver->setDefaults(array(
                 'context' => null,
                 'category' => null,

--- a/Tests/Form/Type/CategorySelectorTypeTest.php
+++ b/Tests/Form/Type/CategorySelectorTypeTest.php
@@ -32,7 +32,7 @@ class CategorySelectorTypeTest extends \PHPUnit_Framework_TestCase
         $definedOptions = $optionsResolver->getDefinedOptions();
         $this->assertContains('category', $definedOptions);
         $this->assertContains('context', $definedOptions);
-        if (class_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')) {
+        if (interface_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')) {
             $this->assertContains('choice_loader', $definedOptions);
             $this->assertNotContains('choice_list', $definedOptions);
         } else {


### PR DESCRIPTION
Made a stupid mistake in my previous PR.
At the last moment I decided not to check on the existence of the class `SimpleChoiceList`, but on `ChoiceLoaderInterface` and forgot to replace `class_exists` with `interface_exists`
My fault.