### PR TITLE
Fix phpunit deprecated methods

### DIFF
--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -22,7 +22,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->contextManager = $this->getMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $this->contextManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\ContextManagerInterface');
     }
 
     public function testAbstractAdminChildren()
@@ -60,7 +60,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin', $this->contextManager,
         ));
 
-        $extension = $this->getMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
+        $extension = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminExtensionInterface');
         $extension->expects($this->once())->method('getPersistentParameters')->will($this->returnValue(null));
 
         $admin->addExtension($extension);
@@ -86,7 +86,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
             'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin', $this->contextManager,
         ));
 
-        $extension = $this->getMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
+        $extension = $this->getMockForAbstractClass('Sonata\AdminBundle\Admin\AdminExtensionInterface');
         $extension->expects($this->once())->method('getPersistentParameters')->will($this->returnValue($extensionParams));
 
         $admin->addExtension($extension);

--- a/Tests/Block/Service/AbstractCategoriesBlockServiceTest.php
+++ b/Tests/Block/Service/AbstractCategoriesBlockServiceTest.php
@@ -42,8 +42,8 @@ final class AbstractCategoriesBlockServiceTest extends AbstractBlockServiceTestC
         parent::setUp();
 
         $this->templating = new FakeTemplating();
-        $this->contextManager = $this->getMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
-        $this->categoryManager = $this->getMock('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
+        $this->contextManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $this->categoryManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
         $this->categoryAdmin = $this->getMockBuilder('Sonata\ClassificationBundle\Admin\CategoryAdmin')->disableOriginalConstructor()->getMock();
     }
 
@@ -76,7 +76,7 @@ final class AbstractCategoriesBlockServiceTest extends AbstractBlockServiceTestC
             ->with($this->equalTo('23'))
             ->will($this->returnValue($category));
 
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->getMockForAbstractClass('Sonata\BlockBundle\Model\BlockInterface');
         $block->expects($this->any())
             ->method('getSetting')
             ->with($this->equalTo('categoryId'))
@@ -99,7 +99,7 @@ final class AbstractCategoriesBlockServiceTest extends AbstractBlockServiceTestC
             ->getMockForAbstractClass();
         $category->expects($this->any())->method('getId')->will($this->returnValue(23));
 
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->getMockForAbstractClass('Sonata\BlockBundle\Model\BlockInterface');
         $block->expects($this->any())
             ->method('getSetting')
             ->with($this->equalTo('categoryId'))
@@ -122,7 +122,7 @@ final class AbstractCategoriesBlockServiceTest extends AbstractBlockServiceTestC
             ->getMockForAbstractClass();
         $category->expects($this->any())->method('getId')->will($this->returnValue(23));
 
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->getMockForAbstractClass('Sonata\BlockBundle\Model\BlockInterface');
         $block->expects($this->any())
             ->method('getSetting')
             ->with($this->equalTo('categoryId'))

--- a/Tests/Block/Service/AbstractCollectionsBlockServiceTest.php
+++ b/Tests/Block/Service/AbstractCollectionsBlockServiceTest.php
@@ -42,8 +42,8 @@ final class AbstractCollectionsBlockServiceTest extends AbstractBlockServiceTest
         parent::setUp();
 
         $this->templating = new FakeTemplating();
-        $this->contextManager = $this->getMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
-        $this->collectionManager = $this->getMock('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
+        $this->contextManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $this->collectionManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
         $this->collectionAdmin = $this->getMockBuilder('Sonata\ClassificationBundle\Admin\CollectionAdmin')->disableOriginalConstructor()->getMock();
     }
 
@@ -76,7 +76,7 @@ final class AbstractCollectionsBlockServiceTest extends AbstractBlockServiceTest
             ->with($this->equalTo('23'))
             ->will($this->returnValue($collection));
 
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->getMockForAbstractClass('Sonata\BlockBundle\Model\BlockInterface');
         $block->expects($this->any())
             ->method('getSetting')
             ->with($this->equalTo('collectionId'))
@@ -99,7 +99,7 @@ final class AbstractCollectionsBlockServiceTest extends AbstractBlockServiceTest
             ->getMockForAbstractClass();
         $collection->expects($this->any())->method('getId')->will($this->returnValue(23));
 
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->getMockForAbstractClass('Sonata\BlockBundle\Model\BlockInterface');
         $block->expects($this->any())
             ->method('getSetting')
             ->with($this->equalTo('collectionId'))
@@ -122,7 +122,7 @@ final class AbstractCollectionsBlockServiceTest extends AbstractBlockServiceTest
             ->getMockForAbstractClass();
         $collection->expects($this->any())->method('getId')->will($this->returnValue(23));
 
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->getMockForAbstractClass('Sonata\BlockBundle\Model\BlockInterface');
         $block->expects($this->any())
             ->method('getSetting')
             ->with($this->equalTo('collectionId'))

--- a/Tests/Block/Service/AbstractTagsBlockServiceTest.php
+++ b/Tests/Block/Service/AbstractTagsBlockServiceTest.php
@@ -42,8 +42,8 @@ final class AbstractTagsBlockServiceTest extends AbstractBlockServiceTestCase
         parent::setUp();
 
         $this->templating = new FakeTemplating();
-        $this->contextManager = $this->getMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
-        $this->tagManager = $this->getMock('Sonata\ClassificationBundle\Model\TagManagerInterface');
+        $this->contextManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $this->tagManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\TagManagerInterface');
         $this->tagAdmin = $this->getMockBuilder('Sonata\ClassificationBundle\Admin\TagAdmin')->disableOriginalConstructor()->getMock();
     }
 
@@ -76,7 +76,7 @@ final class AbstractTagsBlockServiceTest extends AbstractBlockServiceTestCase
             ->with($this->equalTo('23'))
             ->will($this->returnValue($tag));
 
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->getMockForAbstractClass('Sonata\BlockBundle\Model\BlockInterface');
         $block->expects($this->any())
             ->method('getSetting')
             ->with($this->equalTo('tagId'))
@@ -99,7 +99,7 @@ final class AbstractTagsBlockServiceTest extends AbstractBlockServiceTestCase
             ->getMockForAbstractClass();
         $tag->expects($this->any())->method('getId')->will($this->returnValue(23));
 
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->getMockForAbstractClass('Sonata\BlockBundle\Model\BlockInterface');
         $block->expects($this->any())
             ->method('getSetting')
             ->with($this->equalTo('tagId'))
@@ -122,7 +122,7 @@ final class AbstractTagsBlockServiceTest extends AbstractBlockServiceTestCase
             ->getMockForAbstractClass();
         $tag->expects($this->any())->method('getId')->will($this->returnValue(23));
 
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->getMockForAbstractClass('Sonata\BlockBundle\Model\BlockInterface');
         $block->expects($this->any())
             ->method('getSetting')
             ->with($this->equalTo('tagId'))

--- a/Tests/Controller/Api/CategoryControllerTest.php
+++ b/Tests/Controller/Api/CategoryControllerTest.php
@@ -21,12 +21,12 @@ class CategoryControllerTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetCategoriesAction()
     {
-        $paramFetcher = $this->getMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->getMockForAbstractClass('FOS\RestBundle\Request\ParamFetcherInterface');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue(array()));
 
         $pager = $this->getMockBuilder('Sonata\AdminBundle\Datagrid\Pager')->disableOriginalConstructor()->getMock();
 
-        $categoryManager = $this->getMock('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
+        $categoryManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
         $categoryManager->expects($this->once())->method('getPager')->will($this->returnValue($pager));
 
         $this->assertSame($pager, $this->createCategoryController($categoryManager)->getCategoriesAction($paramFetcher));
@@ -34,9 +34,9 @@ class CategoryControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetCategoryAction()
     {
-        $category = $this->getMock('Sonata\ClassificationBundle\Model\CategoryInterface');
+        $category = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CategoryInterface');
 
-        $categoryManager = $this->getMock('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
+        $categoryManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
         $categoryManager->expects($this->once())->method('find')->will($this->returnValue($category));
 
         $this->assertEquals($category, $this->createCategoryController($categoryManager)->getCategoryAction(1));
@@ -53,9 +53,9 @@ class CategoryControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostCategoryAction()
     {
-        $category = $this->getMock('Sonata\ClassificationBundle\Model\CategoryInterface');
+        $category = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CategoryInterface');
 
-        $categoryManager = $this->getMock('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
+        $categoryManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
         $categoryManager->expects($this->once())->method('save')->will($this->returnValue($category));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
@@ -64,7 +64,7 @@ class CategoryControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('getData')->will($this->returnValue($category));
         $form->expects($this->once())->method('all')->will($this->returnValue(array()));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCategoryController($categoryManager, $formFactory)->postCategoryAction(new Request());
@@ -74,7 +74,7 @@ class CategoryControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostCategoryInvalidAction()
     {
-        $categoryManager = $this->getMock('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
+        $categoryManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
         $categoryManager->expects($this->never())->method('save')->will($this->returnValue($categoryManager));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
@@ -82,7 +82,7 @@ class CategoryControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->once())->method('all')->will($this->returnValue(array()));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCategoryController($categoryManager, $formFactory)->postCategoryAction(new Request());
@@ -92,9 +92,9 @@ class CategoryControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPutCategoryAction()
     {
-        $category = $this->getMock('Sonata\ClassificationBundle\Model\CategoryInterface');
+        $category = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CategoryInterface');
 
-        $categoryManager = $this->getMock('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
+        $categoryManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
         $categoryManager->expects($this->once())->method('find')->will($this->returnValue($category));
         $categoryManager->expects($this->once())->method('save')->will($this->returnValue($category));
 
@@ -104,7 +104,7 @@ class CategoryControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('getData')->will($this->returnValue($category));
         $form->expects($this->once())->method('all')->will($this->returnValue(array()));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCategoryController($categoryManager, $formFactory)->putCategoryAction(1, new Request());
@@ -114,9 +114,9 @@ class CategoryControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPutPostInvalidAction()
     {
-        $category = $this->getMock('Sonata\ClassificationBundle\Model\CategoryInterface');
+        $category = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CategoryInterface');
 
-        $categoryManager = $this->getMock('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
+        $categoryManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
         $categoryManager->expects($this->once())->method('find')->will($this->returnValue($category));
         $categoryManager->expects($this->never())->method('save')->will($this->returnValue($category));
 
@@ -125,7 +125,7 @@ class CategoryControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->once())->method('all')->will($this->returnValue(array()));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCategoryController($categoryManager, $formFactory)->putCategoryAction(1, new Request());
@@ -135,9 +135,9 @@ class CategoryControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteCategoryAction()
     {
-        $category = $this->getMock('Sonata\ClassificationBundle\Model\CategoryInterface');
+        $category = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CategoryInterface');
 
-        $categoryManager = $this->getMock('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
+        $categoryManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
         $categoryManager->expects($this->once())->method('find')->will($this->returnValue($category));
         $categoryManager->expects($this->once())->method('delete');
 
@@ -150,7 +150,7 @@ class CategoryControllerTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
 
-        $categoryManager = $this->getMock('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
+        $categoryManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
         $categoryManager->expects($this->once())->method('find')->will($this->returnValue(null));
         $categoryManager->expects($this->never())->method('delete');
 
@@ -168,10 +168,10 @@ class CategoryControllerTest extends \PHPUnit_Framework_TestCase
     protected function createCategoryController($categoryManager = null, $formFactory = null)
     {
         if (null === $categoryManager) {
-            $categoryManager = $this->getMock('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
+            $categoryManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
         }
         if (null === $formFactory) {
-            $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+            $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
         }
 
         return new CategoryController($categoryManager, $formFactory);

--- a/Tests/Controller/Api/CollectionControllerTest.php
+++ b/Tests/Controller/Api/CollectionControllerTest.php
@@ -21,12 +21,12 @@ class CollectionControllerTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetCollectionsAction()
     {
-        $paramFetcher = $this->getMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->getMockForAbstractClass('FOS\RestBundle\Request\ParamFetcherInterface');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue(array()));
 
         $pager = $this->getMockBuilder('Sonata\AdminBundle\Datagrid\Pager')->disableOriginalConstructor()->getMock();
 
-        $collectionManager = $this->getMock('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
+        $collectionManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
         $collectionManager->expects($this->once())->method('getPager')->will($this->returnValue($pager));
 
         $this->assertSame($pager, $this->createCollectionController($collectionManager)->getCollectionsAction($paramFetcher));
@@ -34,9 +34,9 @@ class CollectionControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetCollectionAction()
     {
-        $collection = $this->getMock('Sonata\ClassificationBundle\Model\CollectionInterface');
+        $collection = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CollectionInterface');
 
-        $collectionManager = $this->getMock('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
+        $collectionManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
         $collectionManager->expects($this->once())->method('find')->will($this->returnValue($collection));
 
         $this->assertEquals($collection, $this->createCollectionController($collectionManager)->getCollectionAction(1));
@@ -53,9 +53,9 @@ class CollectionControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostCollectionAction()
     {
-        $collection = $this->getMock('Sonata\ClassificationBundle\Model\CollectionInterface');
+        $collection = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CollectionInterface');
 
-        $collectionManager = $this->getMock('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
+        $collectionManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
         $collectionManager->expects($this->once())->method('save')->will($this->returnValue($collection));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
@@ -64,7 +64,7 @@ class CollectionControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('getData')->will($this->returnValue($collection));
         $form->expects($this->once())->method('all')->will($this->returnValue(array()));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCollectionController($collectionManager, $formFactory)->postCollectionAction(new Request());
@@ -74,9 +74,9 @@ class CollectionControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostCollectionInvalidAction()
     {
-        $collection = $this->getMock('Sonata\ClassificationBundle\Model\CollectionInterface');
+        $collection = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CollectionInterface');
 
-        $collectionManager = $this->getMock('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
+        $collectionManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
         $collectionManager->expects($this->never())->method('save')->will($this->returnValue($collectionManager));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
@@ -84,7 +84,7 @@ class CollectionControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->once())->method('all')->will($this->returnValue(array()));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCollectionController($collectionManager, $formFactory)->postCollectionAction(new Request());
@@ -94,9 +94,9 @@ class CollectionControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPutCollectionAction()
     {
-        $collection = $this->getMock('Sonata\ClassificationBundle\Model\CollectionInterface');
+        $collection = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CollectionInterface');
 
-        $collectionManager = $this->getMock('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
+        $collectionManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
         $collectionManager->expects($this->once())->method('find')->will($this->returnValue($collection));
         $collectionManager->expects($this->once())->method('save')->will($this->returnValue($collection));
 
@@ -106,7 +106,7 @@ class CollectionControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('getData')->will($this->returnValue($collection));
         $form->expects($this->once())->method('all')->will($this->returnValue(array()));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCollectionController($collectionManager, $formFactory)->putCollectionAction(1, new Request());
@@ -116,9 +116,9 @@ class CollectionControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPutPostInvalidAction()
     {
-        $collection = $this->getMock('Sonata\ClassificationBundle\Model\CollectionInterface');
+        $collection = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CollectionInterface');
 
-        $collectionManager = $this->getMock('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
+        $collectionManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
         $collectionManager->expects($this->once())->method('find')->will($this->returnValue($collection));
         $collectionManager->expects($this->never())->method('save')->will($this->returnValue($collection));
 
@@ -127,7 +127,7 @@ class CollectionControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->once())->method('all')->will($this->returnValue(array()));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCollectionController($collectionManager, $formFactory)->putCollectionAction(1, new Request());
@@ -137,9 +137,9 @@ class CollectionControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteCollectionAction()
     {
-        $collection = $this->getMock('Sonata\ClassificationBundle\Model\CollectionInterface');
+        $collection = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CollectionInterface');
 
-        $collectionManager = $this->getMock('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
+        $collectionManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
         $collectionManager->expects($this->once())->method('find')->will($this->returnValue($collection));
         $collectionManager->expects($this->once())->method('delete');
 
@@ -152,7 +152,7 @@ class CollectionControllerTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
 
-        $collectionManager = $this->getMock('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
+        $collectionManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
         $collectionManager->expects($this->once())->method('find')->will($this->returnValue(null));
         $collectionManager->expects($this->never())->method('delete');
 
@@ -170,10 +170,10 @@ class CollectionControllerTest extends \PHPUnit_Framework_TestCase
     protected function createCollectionController($collectionManager = null, $formFactory = null)
     {
         if (null === $collectionManager) {
-            $collectionManager = $this->getMock('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
+            $collectionManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
         }
         if (null === $formFactory) {
-            $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+            $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
         }
 
         return new CollectionController($collectionManager, $formFactory);

--- a/Tests/Controller/Api/ContextControllerTest.php
+++ b/Tests/Controller/Api/ContextControllerTest.php
@@ -21,12 +21,12 @@ class ContextControllerTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetContextsAction()
     {
-        $paramFetcher = $this->getMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->getMockForAbstractClass('FOS\RestBundle\Request\ParamFetcherInterface');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue(array()));
 
         $pager = $this->getMockBuilder('Sonata\AdminBundle\Datagrid\Pager')->disableOriginalConstructor()->getMock();
 
-        $contextManager = $this->getMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $contextManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\ContextManagerInterface');
         $contextManager->expects($this->once())->method('getPager')->will($this->returnValue($pager));
 
         $this->assertSame($pager, $this->createContextController($contextManager)->getContextsAction($paramFetcher));
@@ -34,9 +34,9 @@ class ContextControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetContextAction()
     {
-        $context = $this->getMock('Sonata\ClassificationBundle\Model\ContextInterface');
+        $context = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\ContextInterface');
 
-        $contextManager = $this->getMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $contextManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\ContextManagerInterface');
         $contextManager->expects($this->once())->method('find')->will($this->returnValue($context));
 
         $this->assertEquals($context, $this->createContextController($contextManager)->getContextAction(1));
@@ -53,9 +53,9 @@ class ContextControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostContextAction()
     {
-        $context = $this->getMock('Sonata\ClassificationBundle\Model\ContextInterface');
+        $context = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\ContextInterface');
 
-        $contextManager = $this->getMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $contextManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\ContextManagerInterface');
         $contextManager->expects($this->once())->method('save')->will($this->returnValue($context));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
@@ -64,7 +64,7 @@ class ContextControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('getData')->will($this->returnValue($context));
         $form->expects($this->once())->method('all')->will($this->returnValue(array()));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createContextController($contextManager, $formFactory)->postContextAction(new Request());
@@ -74,7 +74,7 @@ class ContextControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostContextInvalidAction()
     {
-        $contextManager = $this->getMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $contextManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\ContextManagerInterface');
         $contextManager->expects($this->never())->method('save')->will($this->returnValue($contextManager));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
@@ -82,7 +82,7 @@ class ContextControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->once())->method('all')->will($this->returnValue(array()));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createContextController($contextManager, $formFactory)->postContextAction(new Request());
@@ -92,9 +92,9 @@ class ContextControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPutContextAction()
     {
-        $context = $this->getMock('Sonata\ClassificationBundle\Model\ContextInterface');
+        $context = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\ContextInterface');
 
-        $contextManager = $this->getMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $contextManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\ContextManagerInterface');
         $contextManager->expects($this->once())->method('find')->will($this->returnValue($context));
         $contextManager->expects($this->once())->method('save')->will($this->returnValue($context));
 
@@ -104,7 +104,7 @@ class ContextControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('getData')->will($this->returnValue($context));
         $form->expects($this->once())->method('all')->will($this->returnValue(array()));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createContextController($contextManager, $formFactory)->putContextAction(1, new Request());
@@ -114,9 +114,9 @@ class ContextControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPutPostInvalidAction()
     {
-        $context = $this->getMock('Sonata\ClassificationBundle\Model\ContextInterface');
+        $context = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\ContextInterface');
 
-        $contextManager = $this->getMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $contextManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\ContextManagerInterface');
         $contextManager->expects($this->once())->method('find')->will($this->returnValue($context));
         $contextManager->expects($this->never())->method('save')->will($this->returnValue($context));
 
@@ -125,7 +125,7 @@ class ContextControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->once())->method('all')->will($this->returnValue(array()));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createContextController($contextManager, $formFactory)->putContextAction(1, new Request());
@@ -135,9 +135,9 @@ class ContextControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteContextAction()
     {
-        $context = $this->getMock('Sonata\ClassificationBundle\Model\ContextInterface');
+        $context = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\ContextInterface');
 
-        $contextManager = $this->getMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $contextManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\ContextManagerInterface');
         $contextManager->expects($this->once())->method('find')->will($this->returnValue($context));
         $contextManager->expects($this->once())->method('delete');
 
@@ -150,7 +150,7 @@ class ContextControllerTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
 
-        $contextManager = $this->getMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $contextManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\ContextManagerInterface');
         $contextManager->expects($this->once())->method('find')->will($this->returnValue(null));
         $contextManager->expects($this->never())->method('delete');
 
@@ -168,10 +168,10 @@ class ContextControllerTest extends \PHPUnit_Framework_TestCase
     protected function createContextController($contextManager = null, $formFactory = null)
     {
         if (null === $contextManager) {
-            $contextManager = $this->getMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+            $contextManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\ContextManagerInterface');
         }
         if (null === $formFactory) {
-            $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+            $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
         }
 
         return new ContextController($contextManager, $formFactory);

--- a/Tests/Controller/Api/TagControllerTest.php
+++ b/Tests/Controller/Api/TagControllerTest.php
@@ -21,12 +21,12 @@ class TagControllerTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetTagsAction()
     {
-        $paramFetcher = $this->getMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->getMockForAbstractClass('FOS\RestBundle\Request\ParamFetcherInterface');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue(array()));
 
         $pager = $this->getMockBuilder('Sonata\AdminBundle\Datagrid\Pager')->disableOriginalConstructor()->getMock();
 
-        $tagManager = $this->getMock('Sonata\ClassificationBundle\Model\TagManagerInterface');
+        $tagManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\TagManagerInterface');
         $tagManager->expects($this->once())->method('getPager')->will($this->returnValue($pager));
 
         $this->assertSame($pager, $this->createTagController($tagManager)->getTagsAction($paramFetcher));
@@ -34,9 +34,9 @@ class TagControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetTagAction()
     {
-        $tag = $this->getMock('Sonata\ClassificationBundle\Model\TagInterface');
+        $tag = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\TagInterface');
 
-        $tagManager = $this->getMock('Sonata\ClassificationBundle\Model\TagManagerInterface');
+        $tagManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\TagManagerInterface');
         $tagManager->expects($this->once())->method('find')->will($this->returnValue($tag));
 
         $this->assertEquals($tag, $this->createTagController($tagManager)->getTagAction(1));
@@ -53,9 +53,9 @@ class TagControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostTagAction()
     {
-        $tag = $this->getMock('Sonata\ClassificationBundle\Model\TagInterface');
+        $tag = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\TagInterface');
 
-        $tagManager = $this->getMock('Sonata\ClassificationBundle\Model\TagManagerInterface');
+        $tagManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\TagManagerInterface');
         $tagManager->expects($this->once())->method('save')->will($this->returnValue($tag));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
@@ -64,7 +64,7 @@ class TagControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('getData')->will($this->returnValue($tag));
         $form->expects($this->once())->method('all')->will($this->returnValue(array()));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createTagController($tagManager, $formFactory)->postTagAction(new Request());
@@ -74,9 +74,9 @@ class TagControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostTagInvalidAction()
     {
-        $tag = $this->getMock('Sonata\ClassificationBundle\Model\TagInterface');
+        $tag = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\TagInterface');
 
-        $tagManager = $this->getMock('Sonata\ClassificationBundle\Model\TagManagerInterface');
+        $tagManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\TagManagerInterface');
         $tagManager->expects($this->never())->method('save')->will($this->returnValue($tagManager));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
@@ -84,7 +84,7 @@ class TagControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->once())->method('all')->will($this->returnValue(array()));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createTagController($tagManager, $formFactory)->postTagAction(new Request());
@@ -94,9 +94,9 @@ class TagControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPutTagAction()
     {
-        $tag = $this->getMock('Sonata\ClassificationBundle\Model\TagInterface');
+        $tag = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\TagInterface');
 
-        $tagManager = $this->getMock('Sonata\ClassificationBundle\Model\TagManagerInterface');
+        $tagManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\TagManagerInterface');
         $tagManager->expects($this->once())->method('find')->will($this->returnValue($tag));
         $tagManager->expects($this->once())->method('save')->will($this->returnValue($tag));
 
@@ -106,7 +106,7 @@ class TagControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('getData')->will($this->returnValue($tag));
         $form->expects($this->once())->method('all')->will($this->returnValue(array()));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createTagController($tagManager, $formFactory)->putTagAction(1, new Request());
@@ -116,9 +116,9 @@ class TagControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPutPostInvalidAction()
     {
-        $tag = $this->getMock('Sonata\ClassificationBundle\Model\TagInterface');
+        $tag = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\TagInterface');
 
-        $tagManager = $this->getMock('Sonata\ClassificationBundle\Model\TagManagerInterface');
+        $tagManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\TagManagerInterface');
         $tagManager->expects($this->once())->method('find')->will($this->returnValue($tag));
         $tagManager->expects($this->never())->method('save')->will($this->returnValue($tag));
 
@@ -127,7 +127,7 @@ class TagControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->once())->method('all')->will($this->returnValue(array()));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createTagController($tagManager, $formFactory)->putTagAction(1, new Request());
@@ -137,9 +137,9 @@ class TagControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteTagAction()
     {
-        $tag = $this->getMock('Sonata\ClassificationBundle\Model\TagInterface');
+        $tag = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\TagInterface');
 
-        $tagManager = $this->getMock('Sonata\ClassificationBundle\Model\TagManagerInterface');
+        $tagManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\TagManagerInterface');
         $tagManager->expects($this->once())->method('find')->will($this->returnValue($tag));
         $tagManager->expects($this->once())->method('delete');
 
@@ -152,7 +152,7 @@ class TagControllerTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
 
-        $tagManager = $this->getMock('Sonata\ClassificationBundle\Model\TagManagerInterface');
+        $tagManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\TagManagerInterface');
         $tagManager->expects($this->once())->method('find')->will($this->returnValue(null));
         $tagManager->expects($this->never())->method('delete');
 
@@ -170,10 +170,10 @@ class TagControllerTest extends \PHPUnit_Framework_TestCase
     protected function createTagController($tagManager = null, $formFactory = null)
     {
         if (null === $tagManager) {
-            $tagManager = $this->getMock('Sonata\ClassificationBundle\Model\TagManagerInterface');
+            $tagManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\TagManagerInterface');
         }
         if (null === $formFactory) {
-            $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+            $formFactory = $this->getMockForAbstractClass('Symfony\Component\Form\FormFactoryInterface');
         }
 
         return new TagController($tagManager, $formFactory);

--- a/Tests/Controller/CategoryAdminControllerTest.php
+++ b/Tests/Controller/CategoryAdminControllerTest.php
@@ -19,6 +19,7 @@ use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Kernel;
@@ -84,7 +85,7 @@ class CategoryAdminControllerTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->container = $this->getMockForAbstractClass('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $this->request = new Request();
         $this->pool = new Pool($this->container, 'title', 'logo.png');
@@ -97,11 +98,10 @@ class CategoryAdminControllerTest extends \PHPUnit_Framework_TestCase
         $params = &$this->parameters;
         $template = &$this->template;
 
-        $templating = $this->getMock(
-            'Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine',
-            array(),
-            array($this->container, array())
-        );
+        $templating = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine')
+            ->setMethods(array())
+            ->setConstructorArgs(array($this->container, array()))
+            ->getMock();
 
         $templating->expects($this->any())
             ->method('renderResponse')
@@ -132,7 +132,7 @@ class CategoryAdminControllerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $twigRenderer = $this->getMock('Symfony\Bridge\Twig\Form\TwigRendererInterface');
+        $twigRenderer = $this->getMockForAbstractClass('Symfony\Bridge\Twig\Form\TwigRendererInterface');
 
         $formExtension = new FormExtension($twigRenderer);
 
@@ -318,7 +318,7 @@ class CategoryAdminControllerTest extends \PHPUnit_Framework_TestCase
         $this->request->query->set('_list_mode', 'list');
         $this->request->query->set('filter', 'filter[context][value]='.($context ? $context : ''));
 
-        $datagrid = $this->getMock('Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->getMockForAbstractClass('Sonata\AdminBundle\Datagrid\DatagridInterface');
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')
             ->disableOriginalConstructor()
@@ -326,7 +326,7 @@ class CategoryAdminControllerTest extends \PHPUnit_Framework_TestCase
 
         $form->expects($this->once())
              ->method('createView')
-             ->will($this->returnValue($this->getMock('Symfony\Component\Form\FormView')));
+             ->will($this->returnValue(new FormView()));
 
         $this->admin->expects($this->once())
             ->method('getDatagrid')
@@ -357,7 +357,7 @@ class CategoryAdminControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testTreeAction($context, $categories)
     {
-        $datagrid = $this->getMock('Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->getMockForAbstractClass('Sonata\AdminBundle\Datagrid\DatagridInterface');
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')
             ->disableOriginalConstructor()
@@ -365,7 +365,7 @@ class CategoryAdminControllerTest extends \PHPUnit_Framework_TestCase
 
         $form->expects($this->once())
             ->method('createView')
-            ->will($this->returnValue($this->getMock('Symfony\Component\Form\FormView')));
+            ->will($this->returnValue(new FormView()));
 
         $this->admin->expects($this->once())
             ->method('getDatagrid')

--- a/Tests/Entity/CategoryManagerTest.php
+++ b/Tests/Entity/CategoryManagerTest.php
@@ -70,10 +70,10 @@ class CategoryManagerTest extends \PHPUnit_Framework_TestCase
     {
         $em = EntityManagerMockFactory::create($this, $qbCallback, array());
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->getMockForAbstractClass('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        $contextManager = $this->getMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $contextManager = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\ContextManagerInterface');
 
         return new CategoryManager('Sonata\PageBundle\Entity\BaseCategory', $registry, $contextManager);
     }

--- a/Tests/Entity/CollectionManagerTest.php
+++ b/Tests/Entity/CollectionManagerTest.php
@@ -60,7 +60,7 @@ class CollectionManagerTest extends \PHPUnit_Framework_TestCase
     {
         $em = EntityManagerMockFactory::create($this, $qbCallback, array());
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->getMockForAbstractClass('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
         return new CollectionManager('Sonata\PageBundle\Entity\BaseCollection', $registry);

--- a/Tests/Entity/ContextManagerTest.php
+++ b/Tests/Entity/ContextManagerTest.php
@@ -60,7 +60,7 @@ class ContextManagerTest extends \PHPUnit_Framework_TestCase
     {
         $em = EntityManagerMockFactory::create($this, $qbCallback, array());
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->getMockForAbstractClass('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
         return new ContextManager('Sonata\PageBundle\Entity\BaseContext', $registry);

--- a/Tests/Entity/TagManagerTest.php
+++ b/Tests/Entity/TagManagerTest.php
@@ -60,7 +60,7 @@ class TagManagerTest extends \PHPUnit_Framework_TestCase
     {
         $em = EntityManagerMockFactory::create($this, $qbCallback, array());
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->getMockForAbstractClass('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
         return new TagManager('Sonata\PageBundle\Entity\BaseTag', $registry);

--- a/Tests/Form/Type/CategorySelectorTypeTest.php
+++ b/Tests/Form/Type/CategorySelectorTypeTest.php
@@ -21,7 +21,7 @@ class CategorySelectorTypeTest extends \PHPUnit_Framework_TestCase
 {
     public function testConfigureOptions()
     {
-        $manager = $this->getMock('Sonata\CoreBundle\Model\ManagerInterface');
+        $manager = $this->getMockForAbstractClass('Sonata\CoreBundle\Model\ManagerInterface');
         $categorySelectorType = new CategorySelectorType($manager);
         $optionsResolver = new OptionsResolver();
         $categorySelectorType->configureOptions($optionsResolver);


### PR DESCRIPTION
I am targetting this branch, because PR isn't break BC (should be still compatible with old phpunit versions)
## Changelog
```markdown
### Fixed
- Fixed usage of deprecated phpunit methods
```

PHPUnit 5.7.14
Before:
```
WARNINGS!
Tests: 88, Assertions: 256, Warnings: 72.
```
After:
```
OK (88 tests, 256 assertions)
```
