### PR TITLE
Multiple root categories in context. Fixes #233

### DIFF
--- a/Form/Type/CategorySelectorType.php
+++ b/Form/Type/CategorySelectorType.php
@@ -92,9 +92,9 @@ class CategorySelectorType extends AbstractType
         }
 
         if ($options['context'] === null) {
-            $categories = $this->manager->getRootCategories();
+            $categories = $this->manager->getAllRootCategories();
         } else {
-            $categories = array($this->manager->getRootCategory($options['context']));
+            $categories = $this->manager->getRootCategoriesForContext($options['context']);
         }
 
         $choices = array();

--- a/Resources/views/CategoryAdmin/tree.html.twig
+++ b/Resources/views/CategoryAdmin/tree.html.twig
@@ -57,15 +57,15 @@ file that was distributed with this source code.
                                 <strong class="text-info">{{ current_context.name }}</strong> <span class="caret"></span>
                             </button>
                             <ul class="dropdown-menu" role="menu">
-                                {% for category in root_categories %}
+                                {% for context_id, categories in root_categories %}
                                     <li>
-                                        <a href="{{ admin.generateUrl('tree', { 'context': category.context.id }) }}">
-                                            {% if current_context and category.context.id == current_context.id %}
+                                        <a href="{{ admin.generateUrl('tree', { 'context': context_id }) }}">
+                                            {% if current_context and context_id == current_context.id %}
                                                 <span class="pull-right">
                                                     <i class="fa fa-check"></i>
                                                 </span>
                                             {% endif %}
-                                            {{ category.name }}
+                                            {{ categories|join(', ') }}
                                         </a>
                                     </li>
                                 {% endfor %}
@@ -75,10 +75,10 @@ file that was distributed with this source code.
                 </h1>
             </div>
             <div class="box-content">
-                {% if main_category is empty %}
+                {% if current_categories is empty %}
                     {{ tree.navigate_child([], admin, true, 0) }}
                 {% else %}
-                    {{ tree.navigate_child([main_category], admin, true, 0) }}
+                    {{ tree.navigate_child(current_categories, admin, true, 0) }}
                 {% endif %}
             </div>
         </div>

--- a/Tests/Controller/CategoryAdminControllerTest.php
+++ b/Tests/Controller/CategoryAdminControllerTest.php
@@ -400,11 +400,11 @@ class CategoryAdminControllerTest extends \PHPUnit_Framework_TestCase
                 $categoryMock->setContext($this->getContextMock($category[1]));
             }
             $categoryMock->setEnabled(true);
-            array_push($categoriesMock, $categoryMock);
+            $categoriesMock[$categoryMock->getContext()->getId()][] = $categoryMock;
         }
 
         $this->categoryManager->expects($this->any())
-            ->method('getRootCategories')
+            ->method('getRootCategoriesSplitByContexts')
             ->will($this->returnValue($categoriesMock));
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response',

--- a/Tests/Entity/CategoryManagerTest.php
+++ b/Tests/Entity/CategoryManagerTest.php
@@ -11,8 +11,33 @@
 
 namespace Sonata\ClassificationBundle\Tests\Entity;
 
+use Sonata\ClassificationBundle\Entity\BaseCategory;
+use Sonata\ClassificationBundle\Entity\BaseContext;
 use Sonata\ClassificationBundle\Entity\CategoryManager;
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
+
+abstract class CategoryTest extends BaseCategory
+{
+    private $id;
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}
+
+abstract class ContextTest extends BaseContext
+{
+    public function getId()
+    {
+        return $this->id;
+    }
+}
 
 class CategoryManagerTest extends \PHPUnit_Framework_TestCase
 {
@@ -66,9 +91,214 @@ class CategoryManagerTest extends \PHPUnit_Framework_TestCase
             ), 1);
     }
 
-    protected function getCategoryManager($qbCallback)
+    public function testGetCategoriesWithMultipleRootsInContext()
+    {
+        /** @var ContextTest $context */
+        $context = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\ContextTest');
+        $context->setId(1);
+        $context->setName('default');
+        $context->setEnabled(true);
+
+        /** @var CategoryTest $categoryFoo */
+        $categoryFoo = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryFoo->setId(1);
+        $categoryFoo->setName('foo');
+        $categoryFoo->setContext($context);
+        $categoryFoo->setParent(null);
+        $categoryFoo->setEnabled(true);
+
+        /** @var CategoryTest $categoryBar */
+        $categoryBar = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryBar->setId(2);
+        $categoryBar->setName('bar');
+        $categoryBar->setContext($context);
+        $categoryBar->setParent(null);
+        $categoryBar->setEnabled(true);
+
+        $categories = array($categoryFoo, $categoryBar);
+
+        $categoryManager = $this->getCategoryManager(function ($qb) {
+        }, $categories);
+
+        $this->assertSame($categoryManager->getCategories($context), $categories);
+    }
+
+    public function testGetRootCategoryWithChildren()
+    {
+        /** @var ContextTest $context */
+        $context = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\ContextTest');
+        $context->setId(1);
+        $context->setName('default');
+        $context->setEnabled(true);
+
+        /** @var CategoryTest $categoryFoo */
+        $categoryFoo = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryFoo->setId(1);
+        $categoryFoo->setName('foo');
+        $categoryFoo->setContext($context);
+        $categoryFoo->setParent(null);
+        $categoryFoo->setEnabled(true);
+
+        /** @var CategoryTest $categoryBar */
+        $categoryBar = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryBar->setId(2);
+        $categoryBar->setName('bar');
+        $categoryBar->setContext($context);
+        $categoryBar->setParent($categoryFoo);
+        $categoryBar->setEnabled(true);
+
+        $categoryManager = $this->getCategoryManager(function ($qb) {
+        }, array($categoryFoo, $categoryBar));
+
+        $categoryFoo = $categoryManager->getRootCategoryWithChildren($categoryFoo);
+        $this->assertContains($categoryBar, $categoryFoo->getChildren());
+    }
+
+    public function testGetRootCategory()
+    {
+        /** @var ContextTest $context */
+        $context = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\ContextTest');
+        $context->setId(1);
+        $context->setName('default');
+        $context->setEnabled(true);
+
+        /** @var CategoryTest $categoryFoo */
+        $categoryFoo = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryFoo->setId(1);
+        $categoryFoo->setName('foo');
+        $categoryFoo->setContext($context);
+        $categoryFoo->setParent(null);
+        $categoryFoo->setEnabled(true);
+
+        $categoryManager = $this->getCategoryManager(function ($qb) {
+        }, array($categoryFoo));
+
+        $categoryBar = $categoryManager->getRootCategory($context);
+        $this->assertEquals($categoryFoo, $categoryBar);
+    }
+
+    public function testGetRootCategoriesForContext()
+    {
+        /** @var ContextTest $context */
+        $context = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\ContextTest');
+        $context->setId(1);
+        $context->setName('default');
+        $context->setEnabled(true);
+
+        /** @var CategoryTest $categoryFoo */
+        $categoryFoo = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryFoo->setId(1);
+        $categoryFoo->setName('foo');
+        $categoryFoo->setContext($context);
+        $categoryFoo->setParent(null);
+        $categoryFoo->setEnabled(true);
+
+        /** @var CategoryTest $categoryBar */
+        $categoryBar = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryBar->setId(2);
+        $categoryBar->setName('bar');
+        $categoryBar->setContext($context);
+        $categoryBar->setParent($categoryFoo);
+        $categoryBar->setEnabled(true);
+
+        $categoryManager = $this->getCategoryManager(function ($qb) {
+        }, array($categoryFoo, $categoryBar));
+
+        $categories = $categoryManager->getRootCategoriesForContext($context);
+        $this->assertCount(1, $categories);
+        $this->assertContains($categoryFoo, $categories);
+    }
+
+    public function testGetRootCategories()
+    {
+        /** @var ContextTest $contextFoo */
+        $contextFoo = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\ContextTest');
+        $contextFoo->setId(1);
+        $contextFoo->setName('foo');
+        $contextFoo->setEnabled(true);
+
+        /** @var ContextTest $contextBar */
+        $contextBar = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\ContextTest');
+        $contextBar->setId(2);
+        $contextBar->setName('bar');
+        $contextBar->setEnabled(true);
+
+        /** @var CategoryTest $categoryFoo */
+        $categoryFoo = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryFoo->setId(1);
+        $categoryFoo->setName('foo');
+        $categoryFoo->setContext($contextFoo);
+        $categoryFoo->setParent(null);
+        $categoryFoo->setEnabled(true);
+
+        /** @var CategoryTest $categoryBar */
+        $categoryBar = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryBar->setId(2);
+        $categoryBar->setName('bar');
+        $categoryBar->setContext($contextBar);
+        $categoryBar->setParent(null);
+        $categoryBar->setEnabled(true);
+
+        $categoryManager = $this->getCategoryManager(function ($qb) {
+        }, array($categoryFoo, $categoryBar));
+
+        $categories = $categoryManager->getRootCategories(false);
+        $this->assertArrayHasKey($contextFoo->getId(), $categories);
+        $this->assertArrayHasKey($contextBar->getId(), $categories);
+        $this->assertEquals($categoryFoo, $categories[$contextFoo->getId()]);
+        $this->assertEquals($categoryBar, $categories[$contextBar->getId()]);
+    }
+
+    public function testGetRootCategoriesSplitByContexts()
+    {
+        /** @var ContextTest $contextFoo */
+        $contextFoo = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\ContextTest');
+        $contextFoo->setId(1);
+        $contextFoo->setName('foo');
+        $contextFoo->setEnabled(true);
+
+        /** @var ContextTest $contextBar */
+        $contextBar = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\ContextTest');
+        $contextBar->setId(2);
+        $contextBar->setName('bar');
+        $contextBar->setEnabled(true);
+
+        /** @var CategoryTest $categoryFoo */
+        $categoryFoo = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryFoo->setId(1);
+        $categoryFoo->setName('foo');
+        $categoryFoo->setContext($contextFoo);
+        $categoryFoo->setParent(null);
+        $categoryFoo->setEnabled(true);
+
+        /** @var CategoryTest $categoryBar */
+        $categoryBar = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryBar->setId(2);
+        $categoryBar->setName('bar');
+        $categoryBar->setContext($contextBar);
+        $categoryBar->setParent(null);
+        $categoryBar->setEnabled(true);
+
+        $categoryManager = $this->getCategoryManager(function ($qb) {
+        }, array($categoryFoo, $categoryBar));
+
+        $categories = $categoryManager->getRootCategoriesSplitByContexts(false);
+        $this->assertArrayHasKey($contextFoo->getId(), $categories);
+        $this->assertArrayHasKey($contextBar->getId(), $categories);
+        $this->assertContains($categoryFoo, $categories[$contextFoo->getId()]);
+        $this->assertContains($categoryBar, $categories[$contextBar->getId()]);
+    }
+
+    protected function getCategoryManager($qbCallback, $createQueryResult = null)
     {
         $em = EntityManagerMockFactory::create($this, $qbCallback, array());
+
+        if (null != $createQueryResult) {
+            $query = $this->getMockBuilder('Doctrine\ORM\AbstractQuery')->disableOriginalConstructor()->getMock();
+            $query->expects($this->once())->method('execute')->will($this->returnValue($createQueryResult));
+            $query->expects($this->any())->method('setParameter')->will($this->returnValue($query));
+            $em->expects($this->once())->method('createQuery')->will($this->returnValue($query));
+        }
 
         $registry = $this->getMockForAbstractClass('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));


### PR DESCRIPTION
I am targetting this branch, because its BC. 

Closes #233

## Changelog

```markdown
### Added
- new methods for root categories in `CategoryManager`

### Fixed
- `CategoryManager::loadCategories` method now loads all root categories in context
- Categories tree now renders all root categories in context

```

## Screenshots

Same db state

#### Before

<img width="519" alt="2017-03-03 12 03 13" src="https://cloud.githubusercontent.com/assets/1560126/23535344/89aa9f08-0009-11e7-8b90-9cbfcd2c57bd.png">
<img width="514" alt="2017-03-03 12 03 24" src="https://cloud.githubusercontent.com/assets/1560126/23535358/9114ca5c-0009-11e7-87e6-9c213ca8fbd4.png">

#### After

<img width="517" alt="2017-03-03 12 06 08" src="https://cloud.githubusercontent.com/assets/1560126/23535409/eba810be-0009-11e7-9435-775302675b6b.png">
<img width="501" alt="2017-03-03 12 06 46" src="https://cloud.githubusercontent.com/assets/1560126/23535414/f249dd76-0009-11e7-8ad1-de9180958b96.png">



## To do

- [x] Add support for multiple root categories in context
- [x] Add more tests for CategoryManager