### PR TITLE
Fix conflict of datagrid context value and persistent parameter

### DIFF
--- a/Controller/CategoryAdminController.php
+++ b/Controller/CategoryAdminController.php
@@ -40,8 +40,12 @@ class CategoryAdminController extends Controller
         }
 
         $datagrid = $this->admin->getDatagrid();
+        $datagridValues = $datagrid->getValues();
 
-        if ($this->admin->getPersistentParameter('context')) {
+        $datagridContextIsSet = isset($datagridValues['context']['value']) && !empty($datagridValues['context']['value']);
+
+        //ignore `context` persistent parameter if datagrid `context` value is set
+        if ($this->admin->getPersistentParameter('context') && !$datagridContextIsSet) {
             $datagrid->setValue('context', null, $this->admin->getPersistentParameter('context'));
         }
 

--- a/Tests/Controller/CategoryAdminControllerTest.php
+++ b/Tests/Controller/CategoryAdminControllerTest.php
@@ -337,6 +337,14 @@ class CategoryAdminControllerTest extends PHPUnit_Framework_TestCase
             ->method('getForm')
             ->will($this->returnValue($form));
 
+        $datagrid->expects($this->once())
+            ->method('getValues')
+            ->will($this->returnValue(array(
+                'context' => array(
+                    'value' => $context ?: '',
+                ),
+            )));
+
         $this->admin->expects($this->any())
             ->method('getPersistentParameter')
             ->will($this->returnValue($context));


### PR DESCRIPTION
I am targeting this branch, because it is BC.

Closes #286

## Changelog

```markdown
### Fixed
- Fixed conflict of datagrid `context` value and persistent `context` parameter
```