### PR TITLE
Improve Twig 2.x support

### DIFF
--- a/Resources/views/CategoryAdmin/tree.html.twig
+++ b/Resources/views/CategoryAdmin/tree.html.twig
@@ -17,6 +17,7 @@ file that was distributed with this source code.
 
 {% import _self as tree %}
 {% macro navigate_child(collection, admin, root, depth) %}
+    {% import _self as tree %}
     <ul{% if root %} class="sonata-tree sonata-tree--toggleable js-treeview"{% endif %}>
         {% for element in collection %}
             <li class="sonata-ba-list-field" objectId="{{ element.id }}" >
@@ -30,7 +31,7 @@ file that was distributed with this source code.
                 </div>
 
                 {% if element.children|length %}
-                    {{ _self.navigate_child(element.children, admin, false, depth + 1) }}
+                    {{ tree.navigate_child(element.children, admin, false, depth + 1) }}
                 {% endif %}
             </li>
         {% endfor %}


### PR DESCRIPTION
I am targeting this branch, because its BC

## Changelog
<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed using `_self` in `navigate_child` macro in tree template (Twig 2.0 support)
```

## Subject

On Twig 2.x tree template fails with error:
```
Impossible to invoke a method ("navigate_child") on a string variable ("SonataClassificationBundle:CategoryAdmin:tree.html.twig").
```
The problem is in `macro navigate_child` at this line:
```
{{ _self.navigate_child(element.children, admin, false, depth + 1) }}
```
On Twig 1.x `dump(_self)` inside this macro will give us a `TwigTemplate` object, but on 2.x it will be a string `"SonataClassificationBundle:CategoryAdmin:tree.html.twig"`.