### PR TITLE
#303: Changed deprecated twig test from 'sameas' to 'same as'.

### DIFF
--- a/Resources/views/Block/base_block_categories.html.twig
+++ b/Resources/views/Block/base_block_categories.html.twig
@@ -35,8 +35,8 @@ file that was distributed with this source code.
 
 {% macro attributes(attributes) %}
     {% for name, value in attributes %}
-        {%- if value is not none and value is not sameas(false) -%}
-            {{- ' %s="%s"'|format(name, value is sameas(true) ? name|e : value|e)|raw -}}
+        {%- if value is not none and value is not same as(false) -%}
+            {{- ' %s="%s"'|format(name, value is same as(true) ? name|e : value|e)|raw -}}
         {%- endif -%}
     {%- endfor -%}
 {% endmacro %}

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "symfony/form": "^2.3.5 || ^3.0",
         "symfony/http-foundation": "^2.3 || ^3.0",
         "symfony/http-kernel": "^2.3 || ^3.0",
-        "symfony/options-resolver": "^2.3 || ^3.0"
+        "symfony/options-resolver": "^2.3 || ^3.0",
+        "twig/twig": "^1.14.2 || ^2.0"
     },
     "require-dev": {
         "friendsofsymfony/rest-bundle": "^1.1 || ^2.0",


### PR DESCRIPTION
I am targeting this branch, because it's BC.

Closes #303

## Changelog
```markdown
### Added
- Added explicit `twig/twig` dependency
### Fixed
- use `same as` instead of deprecated `sameas` in twig template
```
