### PR TITLE
Fixed paths related to SonataEasyExtendsBundle

### DIFF
--- a/Resources/config/doctrine/Category.mongodb.xml.skeleton
+++ b/Resources/config/doctrine/Category.mongodb.xml.skeleton
@@ -4,7 +4,7 @@
       xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping
                     http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping.xsd">
 
-    <document name="Application\Sonata\ClassificationBundle\Document\Category" collection="classificationCategory">
+    <document name="{{ namespace }}\Document\Category" collection="classificationCategory">
         <id fieldName="id" id="true" />
     </document>
 </doctrine-mongo-mapping>

--- a/Resources/config/doctrine/Category.orm.xml.skeleton
+++ b/Resources/config/doctrine/Category.orm.xml.skeleton
@@ -9,7 +9,7 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\ClassificationBundle\Entity\Category"
+        name="{{ namespace }}\Entity\Category"
         table="classification__category"
         repository-class="Doctrine\ORM\EntityRepository">
 

--- a/Resources/config/doctrine/Collection.orm.xml.skeleton
+++ b/Resources/config/doctrine/Collection.orm.xml.skeleton
@@ -9,7 +9,7 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\ClassificationBundle\Entity\Collection"
+        name="{{ namespace }}\Entity\Collection"
         table="classification__collection"
         repository-class="Doctrine\ORM\EntityRepository">
 

--- a/Resources/config/doctrine/Context.orm.xml.skeleton
+++ b/Resources/config/doctrine/Context.orm.xml.skeleton
@@ -9,7 +9,7 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\ClassificationBundle\Entity\Context"
+        name="{{ namespace }}\Entity\Context"
         table="classification__context"
         repository-class="Doctrine\ORM\EntityRepository">
 

--- a/Resources/config/doctrine/Tag.mongodb.xml.skeleton
+++ b/Resources/config/doctrine/Tag.mongodb.xml.skeleton
@@ -4,7 +4,7 @@
       xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping
                     http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping.xsd">
 
-    <document name="Application\Sonata\ClassificationBundle\Document\Tag" collection="newsTag">
+    <document name="{{ namespace }}\Document\Tag" collection="newsTag">
         <id fieldName="id" id="true" />
     </document>
 </doctrine-mongo-mapping>

--- a/Resources/config/doctrine/Tag.orm.xml.skeleton
+++ b/Resources/config/doctrine/Tag.orm.xml.skeleton
@@ -9,7 +9,7 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\ClassificationBundle\Entity\Tag"
+        name="{{ namespace }}\Entity\Tag"
         table="classification__tag"
         repository-class="Doctrine\ORM\EntityRepository">
 

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "sonata-project/admin-bundle": "^3.1",
         "sonata-project/datagrid-bundle": "^2.2.1",
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
+        "sonata-project/easy-extends-bundle": "^2.2",
         "symfony/config": "^2.3.9 || ^3.0",
         "symfony/console": "^2.3 || ^3.0",
         "symfony/dependency-injection": "^2.3.3 || ^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because my patch is fixing the bug, arisen due to the hardcoded class-path.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed hardcoded paths to classes in `.xml.skeleton` files of config
```

## Subject

<!-- Describe your Pull Request content here -->
Fixed some hardcoded paths, which become invalid after enabling
the '--namespace' option in SonataEasyExtendsBundle's last release
(https://github.com/sonata-project/SonataEasyExtendsBundle/releases/tag/2.2.0)

See also: https://github.com/sonata-project/SonataMediaBundle/pull/1250