### PR TITLE
check if admin has route or show, otherwise render only name on tree …

### DIFF
--- a/Resources/views/CategoryAdmin/tree.html.twig
+++ b/Resources/views/CategoryAdmin/tree.html.twig
@@ -23,7 +23,13 @@ file that was distributed with this source code.
             <li class="sonata-ba-list-field" objectId="{{ element.id }}" >
                 <div class="sonata-tree__item"{% if depth < 2 %} data-treeview-toggled{% endif %}>
                     {% if element.parent or root %}<i class="fa fa-caret-right" data-treeview-toggler></i>{% endif %}
-                    <a class="sonata-tree__item__edit" href="{{ admin.generateObjectUrl('edit', element) }}">{{ element.name }}</a>
+                    {% if admin.hasRoute('edit') and admin.hasAccess('edit') %}
+                        <a class="sonata-tree__item__edit" href="{{ admin.generateObjectUrl('edit', element) }}">{{ element.name }}</a>
+                    {% elseif admin.hasRoute('show') and admin.hasAccess('show') %}
+                        <a class="sonata-tree__item__edit" href="{{ admin.generateObjectUrl('show', element) }}">{{ element.name }}</a>
+                    {% else %}
+                        {{ element.name }}
+                    {% endif %}
                     <i class="text-muted">{{ element.description }}</i>
                     {#<a class="label label-default pull-right" href="{{ admin.generateObjectUrl('edit', element) }}">edit <i class="fa fa-magic"></i></a>#}
                     {% if element.enabled %}<span class="label label-success pull-right"><i class="fa fa-check"></i> {{ admin.trans('active', {}, admin.translationDomain) }}</span>{% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is a bug fix


<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #308

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Added route check to tree view `Resources/views/CategoryAdmin/tree.html.twig`. If there aren't edit AND show routes, render element name only.
```

## Subject

<!-- Describe your Pull Request content here -->

See #308 