### PR TITLE
Adding SonataEasyExtendsBundle to installation

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -5,20 +5,19 @@
 Installation
 ============
 
-* Add ``SonataClassificationBundle`` to your vendor/bundles directory with the deps file:
+* Add ``SonataClassificationBundle`` via composer:
 
-.. code-block:: php
+.. code-block:: bash
 
-    // composer.json
+   $ composer require sonata-project/classification-bundle
 
-    "require": {
-    //...
-        "sonata-project/classification-bundle": "dev-master",
-    //...
-    }
+* Add ``SonataEasyExtendsBundle`` to the dev environment via composer:
 
+.. code-block:: bash
 
-* Add ``SonataClassificationBundle`` to your application kernel:
+   $ composer require --dev sonata-project/easy-extends-bundle
+
+* Add ``SonataClassificationBundle`` and  ``SonataEasyExtendsBundle`` to your application kernel:
 
 .. code-block:: php
 
@@ -26,11 +25,19 @@ Installation
 
     public function registerBundles()
     {
-        return array(
+        $bundles = [
             // ...
             new Sonata\ClassificationBundle\SonataClassificationBundle(),
             // ...
-        );
+        ];
+        
+        if (in_array($this->getEnvironment(), ['dev', 'test'], true)) {
+            // ...
+            $bundles[] = new Sonata\EasyExtendsBundle\SonataEasyExtendsBundle();
+            // ...
+        }
+        
+        return $bundles;
     }
 
 * Create a configuration file named ``sonata_classification.yml``:


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because its this the the branch that I used for the documentation. However I am unsure if this needs to be ported to the master branch.

In case of bug fix, `3.x` **MUST** be targeted.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes N/A


## Adding SonataEasyExtendsBundle to installation

In order to run 
``php app/console sonata:easy-extends:generate --dest=src SonataClassificationBundle`` you must first have the SonataEasyExtendsBundle installed and configured in the AppKernel.
This change updates the installation process to demonstrate how to do this.