### PR TITLE
Remove form field type deprecations

### DIFF
--- a/Admin/CategoryAdmin.php
+++ b/Admin/CategoryAdmin.php
@@ -14,7 +14,11 @@ namespace Sonata\ClassificationBundle\Admin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\AdminBundle\Route\RouteCollection;
+use Sonata\ClassificationBundle\Form\Type\CategorySelectorType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Validator\Constraints\Valid;
 
 class CategoryAdmin extends ContextAwareAdmin
@@ -60,7 +64,7 @@ EOT
         $formMapper
             ->with('General', array('class' => 'col-md-6'))
                 ->add('name')
-                ->add('description', 'textarea', array(
+                ->add('description', TextareaType::class, array(
                     'required' => false,
                 ))
         ;
@@ -68,7 +72,7 @@ EOT
         if ($this->hasSubject()) {
             if ($this->getSubject()->getParent() !== null || $this->getSubject()->getId() === null) { // root category cannot have a parent
                 $formMapper
-                  ->add('parent', 'sonata_category_selector', array(
+                  ->add('parent', CategorySelectorType::class, array(
                       'category' => $this->getSubject() ?: null,
                       'model_manager' => $this->getModelManager(),
                       'class' => $this->getClass(),
@@ -86,7 +90,7 @@ EOT
                 ->add('enabled', null, array(
                     'required' => false,
                 ))
-                ->add('position', 'integer', array(
+                ->add('position', IntegerType::class, array(
                     'required' => false,
                     'data' => $position,
                 ))
@@ -96,7 +100,7 @@ EOT
         if (interface_exists('Sonata\MediaBundle\Model\MediaInterface')) {
             $formMapper
                 ->with('General')
-                    ->add('media', 'sonata_type_model_list',
+                    ->add('media', ModelListType::class,
                         array(
                             'required' => false,
                         ),

--- a/Admin/CategoryAdmin.php
+++ b/Admin/CategoryAdmin.php
@@ -14,11 +14,7 @@ namespace Sonata\ClassificationBundle\Admin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\AdminBundle\Route\RouteCollection;
-use Sonata\ClassificationBundle\Form\Type\CategorySelectorType;
-use Symfony\Component\Form\Extension\Core\Type\IntegerType;
-use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Validator\Constraints\Valid;
 
 class CategoryAdmin extends ContextAwareAdmin
@@ -64,21 +60,34 @@ EOT
         $formMapper
             ->with('General', array('class' => 'col-md-6'))
                 ->add('name')
-                ->add('description', TextareaType::class, array(
-                    'required' => false,
-                ))
+                ->add('description',
+                    // NEXT_MAJOR: remove when dropping Symfony <2.8 support
+                    method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                        ? 'Symfony\Component\Form\Extension\Core\Type\TextareaType'
+                        : 'textarea',
+                    array(
+                        'required' => false,
+                    )
+                )
         ;
 
         if ($this->hasSubject()) {
             if ($this->getSubject()->getParent() !== null || $this->getSubject()->getId() === null) { // root category cannot have a parent
                 $formMapper
-                  ->add('parent', CategorySelectorType::class, array(
-                      'category' => $this->getSubject() ?: null,
-                      'model_manager' => $this->getModelManager(),
-                      'class' => $this->getClass(),
-                      'required' => true,
-                      'context' => $this->getSubject()->getContext(),
-                    ));
+                    ->add('parent',
+                        // NEXT_MAJOR: remove when dropping Symfony <2.8 support
+                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                            ? 'Sonata\ClassificationBundle\Form\Type\CategorySelectorType'
+                            : 'sonata_category_selector',
+                        array(
+                            'category' => $this->getSubject() ?: null,
+                            'model_manager' => $this->getModelManager(),
+                            'class' => $this->getClass(),
+                            'required' => true,
+                            'context' => $this->getSubject()->getContext(),
+                        )
+                    )
+                ;
             }
         }
 
@@ -90,17 +99,27 @@ EOT
                 ->add('enabled', null, array(
                     'required' => false,
                 ))
-                ->add('position', IntegerType::class, array(
-                    'required' => false,
-                    'data' => $position,
-                ))
+                ->add('position',
+                    // NEXT_MAJOR: remove when dropping Symfony <2.8 support
+                    method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                        ? 'Symfony\Component\Form\Extension\Core\Type\IntegerType'
+                        : 'integer',
+                    array(
+                        'required' => false,
+                        'data' => $position,
+                    )
+                )
             ->end()
         ;
 
         if (interface_exists('Sonata\MediaBundle\Model\MediaInterface')) {
             $formMapper
                 ->with('General')
-                    ->add('media', ModelListType::class,
+                    ->add('media',
+                        // NEXT_MAJOR: remove when dropping Symfony <2.8 support
+                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                            ? 'Sonata\AdminBundle\Form\Type\ModelListType'
+                            : 'sonata_type_model_list',
                         array(
                             'required' => false,
                         ),

--- a/Admin/CollectionAdmin.php
+++ b/Admin/CollectionAdmin.php
@@ -14,8 +14,6 @@ namespace Sonata\ClassificationBundle\Admin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Form\Type\ModelListType;
-use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Validator\Constraints\Valid;
 
 class CollectionAdmin extends ContextAwareAdmin
@@ -52,9 +50,15 @@ EOT
     {
         $formMapper
             ->add('name')
-            ->add('description', TextareaType::class, array(
-                'required' => false,
-            ))
+            ->add('description',
+                // NEXT_MAJOR: remove when dropping Symfony <2.8 support
+                method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                    ? 'Symfony\Component\Form\Extension\Core\Type\TextareaType'
+                    : 'textarea',
+                array(
+                    'required' => false,
+                )
+            )
             ->add('context')
             ->add('enabled', null, array(
                 'required' => false,
@@ -62,7 +66,11 @@ EOT
         ;
 
         if (interface_exists('Sonata\MediaBundle\Model\MediaInterface')) {
-            $formMapper->add('media', ModelListType::class,
+            $formMapper->add('media',
+                // NEXT_MAJOR: remove when dropping Symfony <2.8 support
+                method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                    ? 'Sonata\AdminBundle\Form\Type\ModelListType'
+                    : 'sonata_type_model_list',
                 array('required' => false),
                 array(
                     'link_parameters' => array(

--- a/Admin/CollectionAdmin.php
+++ b/Admin/CollectionAdmin.php
@@ -14,6 +14,8 @@ namespace Sonata\ClassificationBundle\Admin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ModelListType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Validator\Constraints\Valid;
 
 class CollectionAdmin extends ContextAwareAdmin
@@ -50,7 +52,7 @@ EOT
     {
         $formMapper
             ->add('name')
-            ->add('description', 'textarea', array(
+            ->add('description', TextareaType::class, array(
                 'required' => false,
             ))
             ->add('context')
@@ -60,7 +62,7 @@ EOT
         ;
 
         if (interface_exists('Sonata\MediaBundle\Model\MediaInterface')) {
-            $formMapper->add('media', 'sonata_type_model_list',
+            $formMapper->add('media', ModelListType::class,
                 array('required' => false),
                 array(
                     'link_parameters' => array(

--- a/Block/Service/AbstractCategoriesBlockService.php
+++ b/Block/Service/AbstractCategoriesBlockService.php
@@ -18,11 +18,8 @@ use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
-use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -91,21 +88,40 @@ abstract class AbstractCategoriesBlockService extends AbstractClassificationBloc
             ),
         ));
 
-        $formMapper->add('settings', ImmutableArrayType::class, array(
-            'keys' => array(
-                array('title', TextType::class, array(
-                    'label' => 'form.label_title',
-                    'required' => false,
-                )),
-                array('context', ChoiceType::class, array(
-                    'label' => 'form.label_context',
-                    'required' => false,
-                    'choices' => $this->getContextChoices(),
-                )),
-                array($adminField, null, array()),
-            ),
-            'translation_domain' => 'SonataClassificationBundle',
-        ));
+        $formMapper->add(
+            'settings',
+            // NEXT_MAJOR: remove when dropping Symfony <2.8 support
+            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Sonata\CoreBundle\Form\Type\ImmutableArrayType'
+                : 'sonata_type_immutable_array',
+            array(
+                'keys' => array(
+                    array('title',
+                        // NEXT_MAJOR: remove when dropping Symfony <2.8 support
+                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                            ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+                            : 'text',
+                        array(
+                            'label' => 'form.label_title',
+                            'required' => false,
+                        )
+                    ),
+                    array('context',
+                        // NEXT_MAJOR: remove when dropping Symfony <2.8 support
+                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+                            : 'choice',
+                        array(
+                            'label' => 'form.label_context',
+                            'required' => false,
+                            'choices' => $this->getContextChoices(),
+                        )
+                    ),
+                    array($adminField, null, array()),
+                ),
+                'translation_domain' => 'SonataClassificationBundle',
+            )
+        );
     }
 
     /**

--- a/Block/Service/AbstractCategoriesBlockService.php
+++ b/Block/Service/AbstractCategoriesBlockService.php
@@ -104,7 +104,7 @@ abstract class AbstractCategoriesBlockService extends AbstractClassificationBloc
                         array(
                             'label' => 'form.label_title',
                             'required' => false,
-                        )
+                        ),
                     ),
                     array('context',
                         // NEXT_MAJOR: remove when dropping Symfony <2.8 support
@@ -115,7 +115,7 @@ abstract class AbstractCategoriesBlockService extends AbstractClassificationBloc
                             'label' => 'form.label_context',
                             'required' => false,
                             'choices' => $this->getContextChoices(),
-                        )
+                        ),
                     ),
                     array($adminField, null, array()),
                 ),

--- a/Block/Service/AbstractCategoriesBlockService.php
+++ b/Block/Service/AbstractCategoriesBlockService.php
@@ -18,8 +18,11 @@ use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -88,13 +91,13 @@ abstract class AbstractCategoriesBlockService extends AbstractClassificationBloc
             ),
         ));
 
-        $formMapper->add('settings', 'sonata_type_immutable_array', array(
+        $formMapper->add('settings', ImmutableArrayType::class, array(
             'keys' => array(
-                array('title', 'text', array(
+                array('title', TextType::class, array(
                     'label' => 'form.label_title',
                     'required' => false,
                 )),
-                array('context', 'choice', array(
+                array('context', ChoiceType::class, array(
                     'label' => 'form.label_context',
                     'required' => false,
                     'choices' => $this->getContextChoices(),

--- a/Block/Service/AbstractClassificationBlockService.php
+++ b/Block/Service/AbstractClassificationBlockService.php
@@ -78,7 +78,7 @@ abstract class AbstractClassificationBlockService extends AbstractAdminBlockServ
     }
 
     /**
-     * Returns an context choice array.
+     * Returns a context choice array.
      *
      * @return string[]
      */

--- a/Block/Service/AbstractCollectionsBlockService.php
+++ b/Block/Service/AbstractCollectionsBlockService.php
@@ -18,8 +18,11 @@ use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\ClassificationBundle\Model\CollectionInterface;
 use Sonata\ClassificationBundle\Model\CollectionManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -89,13 +92,13 @@ abstract class AbstractCollectionsBlockService extends AbstractClassificationBlo
             ),
         ));
 
-        $formMapper->add('settings', 'sonata_type_immutable_array', array(
+        $formMapper->add('settings', ImmutableArrayType::class, array(
             'keys' => array(
-                array('title', 'text', array(
+                array('title', TextType::class, array(
                     'label' => 'form.label_title',
                     'required' => false,
                 )),
-                array('context', 'choice', array(
+                array('context', ChoiceType::class, array(
                     'label' => 'form.label_context',
                     'required' => false,
                     'choices' => $this->getContextChoices(),

--- a/Block/Service/AbstractCollectionsBlockService.php
+++ b/Block/Service/AbstractCollectionsBlockService.php
@@ -18,11 +18,8 @@ use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\ClassificationBundle\Model\CollectionInterface;
 use Sonata\ClassificationBundle\Model\CollectionManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
-use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -92,21 +89,40 @@ abstract class AbstractCollectionsBlockService extends AbstractClassificationBlo
             ),
         ));
 
-        $formMapper->add('settings', ImmutableArrayType::class, array(
-            'keys' => array(
-                array('title', TextType::class, array(
-                    'label' => 'form.label_title',
-                    'required' => false,
-                )),
-                array('context', ChoiceType::class, array(
-                    'label' => 'form.label_context',
-                    'required' => false,
-                    'choices' => $this->getContextChoices(),
-                )),
-                array($adminField, null, array()),
-            ),
-            'translation_domain' => 'SonataClassificationBundle',
-        ));
+        $formMapper->add(
+            'settings',
+            // NEXT_MAJOR: remove when dropping Symfony <2.8 support
+            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Sonata\CoreBundle\Form\Type\ImmutableArrayType'
+                : 'sonata_type_immutable_array',
+            array(
+                'keys' => array(
+                    array('title',
+                        // NEXT_MAJOR: remove when dropping Symfony <2.8 support
+                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                            ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+                            : 'text',
+                        array(
+                            'label' => 'form.label_title',
+                            'required' => false,
+                        )
+                    ),
+                    array('context',
+                        // NEXT_MAJOR: remove when dropping Symfony <2.8 support
+                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+                            : 'choice',
+                        array(
+                            'label' => 'form.label_context',
+                            'required' => false,
+                            'choices' => $this->getContextChoices(),
+                        )
+                    ),
+                    array($adminField, null, array()),
+                ),
+                'translation_domain' => 'SonataClassificationBundle',
+            )
+        );
     }
 
     /**

--- a/Block/Service/AbstractCollectionsBlockService.php
+++ b/Block/Service/AbstractCollectionsBlockService.php
@@ -105,7 +105,7 @@ abstract class AbstractCollectionsBlockService extends AbstractClassificationBlo
                         array(
                             'label' => 'form.label_title',
                             'required' => false,
-                        )
+                        ),
                     ),
                     array('context',
                         // NEXT_MAJOR: remove when dropping Symfony <2.8 support
@@ -116,7 +116,7 @@ abstract class AbstractCollectionsBlockService extends AbstractClassificationBlo
                             'label' => 'form.label_context',
                             'required' => false,
                             'choices' => $this->getContextChoices(),
-                        )
+                        ),
                     ),
                     array($adminField, null, array()),
                 ),

--- a/Block/Service/AbstractTagsBlockService.php
+++ b/Block/Service/AbstractTagsBlockService.php
@@ -19,11 +19,8 @@ use Sonata\ClassificationBundle\Model\ContextInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 use Sonata\ClassificationBundle\Model\TagInterface;
 use Sonata\ClassificationBundle\Model\TagManagerInterface;
-use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -99,21 +96,39 @@ abstract class AbstractTagsBlockService extends AbstractClassificationBlockServi
             ),
         ));
 
-        $formMapper->add('settings', ImmutableArrayType::class, array(
-            'keys' => array(
-                array('title', TextType::class, array(
-                    'label' => 'form.label_title',
-                    'required' => false,
-                )),
-                array('context', ChoiceType::class, array(
-                    'label' => 'form.label_context',
-                    'required' => false,
-                    'choices' => $contextChoices,
-                )),
-                array($adminField, null, array()),
-            ),
-            'translation_domain' => 'SonataClassificationBundle',
-        ));
+        $formMapper->add('settings',
+            // NEXT_MAJOR: remove when dropping Symfony <2.8 support
+            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Sonata\CoreBundle\Form\Type\ImmutableArrayType'
+                : 'sonata_type_immutable_array',
+            array(
+                'keys' => array(
+                    array('title',
+                        // NEXT_MAJOR: remove when dropping Symfony <2.8 support
+                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                            ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+                            : 'text',
+                        array(
+                            'label' => 'form.label_title',
+                            'required' => false,
+                        )
+                    ),
+                    array('context',
+                        // NEXT_MAJOR: remove when dropping Symfony <2.8 support
+                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+                            : 'choice',
+                        array(
+                            'label' => 'form.label_context',
+                            'required' => false,
+                            'choices' => $this->getContextChoices(),
+                        )
+                    ),
+                    array($adminField, null, array()),
+                ),
+                'translation_domain' => 'SonataClassificationBundle',
+            )
+        );
     }
 
     /**

--- a/Block/Service/AbstractTagsBlockService.php
+++ b/Block/Service/AbstractTagsBlockService.php
@@ -111,7 +111,7 @@ abstract class AbstractTagsBlockService extends AbstractClassificationBlockServi
                         array(
                             'label' => 'form.label_title',
                             'required' => false,
-                        )
+                        ),
                     ),
                     array('context',
                         // NEXT_MAJOR: remove when dropping Symfony <2.8 support
@@ -122,7 +122,7 @@ abstract class AbstractTagsBlockService extends AbstractClassificationBlockServi
                             'label' => 'form.label_context',
                             'required' => false,
                             'choices' => $this->getContextChoices(),
-                        )
+                        ),
                     ),
                     array($adminField, null, array()),
                 ),

--- a/Block/Service/AbstractTagsBlockService.php
+++ b/Block/Service/AbstractTagsBlockService.php
@@ -19,8 +19,11 @@ use Sonata\ClassificationBundle\Model\ContextInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 use Sonata\ClassificationBundle\Model\TagInterface;
 use Sonata\ClassificationBundle\Model\TagManagerInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -96,13 +99,13 @@ abstract class AbstractTagsBlockService extends AbstractClassificationBlockServi
             ),
         ));
 
-        $formMapper->add('settings', 'sonata_type_immutable_array', array(
+        $formMapper->add('settings', ImmutableArrayType::class, array(
             'keys' => array(
-                array('title', 'text', array(
+                array('title', TextType::class, array(
                     'label' => 'form.label_title',
                     'required' => false,
                 )),
-                array('context', 'choice', array(
+                array('context', ChoiceType::class, array(
                     'label' => 'form.label_context',
                     'required' => false,
                     'choices' => $contextChoices,

--- a/Form/Type/CategorySelectorType.php
+++ b/Form/Type/CategorySelectorType.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\ClassificationBundle\Form\Type;
 
+use Sonata\AdminBundle\Form\Type\ModelType;
 use Sonata\ClassificationBundle\Form\ChoiceList\CategoryChoiceLoader;
 use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
@@ -113,7 +114,7 @@ class CategorySelectorType extends AbstractType
      */
     public function getParent()
     {
-        return 'sonata_type_model';
+        return ModelType::class;
     }
 
     /**

--- a/Form/Type/CategorySelectorType.php
+++ b/Form/Type/CategorySelectorType.php
@@ -11,7 +11,6 @@
 
 namespace Sonata\ClassificationBundle\Form\Type;
 
-use Sonata\AdminBundle\Form\Type\ModelType;
 use Sonata\ClassificationBundle\Form\ChoiceList\CategoryChoiceLoader;
 use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
@@ -114,7 +113,10 @@ class CategorySelectorType extends AbstractType
      */
     public function getParent()
     {
-        return ModelType::class;
+        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\AdminBundle\Form\Type\ModelType'
+            : 'sonata_type_model';
     }
 
     /**


### PR DESCRIPTION
I am targeting this branch, because it removes deprecations and it's BC.

Closes #314

## Changelog

```markdown
### Changed
- Changed string type declaration of form fields to the fully-qualified type class name.
```

## Subject

Remove deprecation warnings on form type fields to use the fully-qualified type class name of them.
