### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/Admin/CategoryAdmin.php
+++ b/Admin/CategoryAdmin.php
@@ -14,7 +14,12 @@ namespace Sonata\ClassificationBundle\Admin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\AdminBundle\Route\RouteCollection;
+use Sonata\ClassificationBundle\Form\Type\CategorySelectorType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Validator\Constraints\Valid;
 
 class CategoryAdmin extends ContextAwareAdmin
@@ -60,33 +65,21 @@ EOT
         $formMapper
             ->with('General', ['class' => 'col-md-6'])
                 ->add('name')
-                ->add('description',
-                    // NEXT_MAJOR: remove when dropping Symfony <2.8 support
-                    method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                        ? 'Symfony\Component\Form\Extension\Core\Type\TextareaType'
-                        : 'textarea',
-                    [
-                        'required' => false,
-                    ]
-                )
+                ->add('description', TextareaType::class, [
+                    'required' => false,
+                ])
         ;
 
         if ($this->hasSubject()) {
             if ($this->getSubject()->getParent() !== null || $this->getSubject()->getId() === null) { // root category cannot have a parent
                 $formMapper
-                    ->add('parent',
-                        // NEXT_MAJOR: remove when dropping Symfony <2.8 support
-                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                            ? 'Sonata\ClassificationBundle\Form\Type\CategorySelectorType'
-                            : 'sonata_category_selector',
-                        [
-                            'category' => $this->getSubject() ?: null,
-                            'model_manager' => $this->getModelManager(),
-                            'class' => $this->getClass(),
-                            'required' => true,
-                            'context' => $this->getSubject()->getContext(),
-                        ]
-                    )
+                    ->add('parent', CategorySelectorType::class, [
+                        'category' => $this->getSubject() ?: null,
+                        'model_manager' => $this->getModelManager(),
+                        'class' => $this->getClass(),
+                        'required' => true,
+                        'context' => $this->getSubject()->getContext(),
+                    ])
                 ;
             }
         }
@@ -96,40 +89,27 @@ EOT
         $formMapper
             ->end()
             ->with('Options', ['class' => 'col-md-6'])
-                ->add('enabled', null, [
+                ->add('enabled', CheckboxType::class, [
                     'required' => false,
                 ])
-                ->add('position',
-                    // NEXT_MAJOR: remove when dropping Symfony <2.8 support
-                    method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                        ? 'Symfony\Component\Form\Extension\Core\Type\IntegerType'
-                        : 'integer',
-                    [
-                        'required' => false,
-                        'data' => $position,
-                    ]
-                )
+                ->add('position', IntegerType::class, [
+                    'required' => false,
+                    'data' => $position,
+                ])
             ->end()
         ;
 
         if (interface_exists('Sonata\MediaBundle\Model\MediaInterface')) {
             $formMapper
                 ->with('General')
-                    ->add('media',
-                        // NEXT_MAJOR: remove when dropping Symfony <2.8 support
-                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                            ? 'Sonata\AdminBundle\Form\Type\ModelListType'
-                            : 'sonata_type_model_list',
-                        [
-                            'required' => false,
+                    ->add('media', ModelListType::class, [
+                        'required' => false,
+                    ], [
+                        'link_parameters' => [
+                            'provider' => 'sonata.media.provider.image',
+                            'context' => 'sonata_category',
                         ],
-                        [
-                            'link_parameters' => [
-                                'provider' => 'sonata.media.provider.image',
-                                'context' => 'sonata_category',
-                            ],
-                        ]
-                    )
+                    ])
                 ->end();
         }
     }

--- a/Admin/CollectionAdmin.php
+++ b/Admin/CollectionAdmin.php
@@ -14,6 +14,9 @@ namespace Sonata\ClassificationBundle\Admin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ModelListType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Validator\Constraints\Valid;
 
 class CollectionAdmin extends ContextAwareAdmin
@@ -50,35 +53,24 @@ EOT
     {
         $formMapper
             ->add('name')
-            ->add('description',
-                // NEXT_MAJOR: remove when dropping Symfony <2.8 support
-                method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                    ? 'Symfony\Component\Form\Extension\Core\Type\TextareaType'
-                    : 'textarea',
-                [
-                    'required' => false,
-                ]
-            )
+            ->add('description', TextareaType::class, [
+                'required' => false,
+            ])
             ->add('context')
-            ->add('enabled', null, [
+            ->add('enabled', CheckboxType::class, [
                 'required' => false,
             ])
         ;
 
         if (interface_exists('Sonata\MediaBundle\Model\MediaInterface')) {
-            $formMapper->add('media',
-                // NEXT_MAJOR: remove when dropping Symfony <2.8 support
-                method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                    ? 'Sonata\AdminBundle\Form\Type\ModelListType'
-                    : 'sonata_type_model_list',
-                ['required' => false],
-                [
-                    'link_parameters' => [
-                        'provider' => 'sonata.media.provider.image',
-                        'context' => 'sonata_collection',
-                    ],
-                ]
-            );
+            $formMapper->add('media', ModelListType::class, [
+                'required' => false,
+            ], [
+                'link_parameters' => [
+                    'provider' => 'sonata.media.provider.image',
+                    'context' => 'sonata_collection',
+                ],
+            ]);
         }
     }
 

--- a/Admin/ContextAdmin.php
+++ b/Admin/ContextAdmin.php
@@ -15,6 +15,7 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 
 class ContextAdmin extends AbstractAdmin
 {
@@ -28,7 +29,7 @@ class ContextAdmin extends AbstractAdmin
                 ->add('id')
             ->ifEnd()
             ->add('name')
-            ->add('enabled', null, [
+            ->add('enabled', CheckboxType::class, [
                 'required' => false,
             ])
         ;

--- a/Admin/TagAdmin.php
+++ b/Admin/TagAdmin.php
@@ -14,6 +14,7 @@ namespace Sonata\ClassificationBundle\Admin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 
 class TagAdmin extends ContextAwareAdmin
 {
@@ -31,7 +32,9 @@ class TagAdmin extends ContextAwareAdmin
             $formMapper->add('slug');
         }
 
-        $formMapper->add('enabled', null, ['required' => false]);
+        $formMapper->add('enabled', CheckboxType::class, [
+            'required' => false,
+        ]);
     }
 
     /**

--- a/Block/Service/AbstractCategoriesBlockService.php
+++ b/Block/Service/AbstractCategoriesBlockService.php
@@ -18,8 +18,11 @@ use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -88,35 +91,17 @@ abstract class AbstractCategoriesBlockService extends AbstractClassificationBloc
             ],
         ]);
 
-        $formMapper->add(
-            'settings',
-            // NEXT_MAJOR: remove when dropping Symfony <2.8 support
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Sonata\CoreBundle\Form\Type\ImmutableArrayType'
-                : 'sonata_type_immutable_array',
-            [
+        $formMapper->add(ImmutableArrayType::class, [
                 'keys' => [
-                    ['title',
-                        // NEXT_MAJOR: remove when dropping Symfony <2.8 support
-                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                            ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-                            : 'text',
-                        [
-                            'label' => 'form.label_title',
-                            'required' => false,
-                        ],
-                    ],
-                    ['context',
-                        // NEXT_MAJOR: remove when dropping Symfony <2.8 support
-                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-                            : 'choice',
-                        [
-                            'label' => 'form.label_context',
-                            'required' => false,
-                            'choices' => $this->getContextChoices(),
-                        ],
-                    ],
+                    ['title', TextType::class, [
+                        'label' => 'form.label_title',
+                        'required' => false,
+                    ]],
+                    ['context', ChoiceType::class, [
+                        'label' => 'form.label_context',
+                        'required' => false,
+                        'choices' => $this->getContextChoices(),
+                    ]],
                     [$adminField, null, []],
                 ],
                 'translation_domain' => 'SonataClassificationBundle',

--- a/Block/Service/AbstractClassificationBlockService.php
+++ b/Block/Service/AbstractClassificationBlockService.php
@@ -14,6 +14,7 @@ namespace Sonata\ClassificationBundle\Block\Service;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ModelTypeList;
 use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\ClassificationBundle\Model\ContextInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
@@ -74,7 +75,7 @@ abstract class AbstractClassificationBlockService extends AbstractAdminBlockServ
             'required' => false,
         ], $fieldOptions);
 
-        return $formMapper->create($formField, 'sonata_type_model_list', $fieldOptions);
+        return $formMapper->create($formField, ModelTypeList::class, $fieldOptions);
     }
 
     /**

--- a/Block/Service/AbstractCollectionsBlockService.php
+++ b/Block/Service/AbstractCollectionsBlockService.php
@@ -18,8 +18,11 @@ use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\ClassificationBundle\Model\CollectionInterface;
 use Sonata\ClassificationBundle\Model\CollectionManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -91,33 +94,17 @@ abstract class AbstractCollectionsBlockService extends AbstractClassificationBlo
 
         $formMapper->add(
             'settings',
-            // NEXT_MAJOR: remove when dropping Symfony <2.8 support
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Sonata\CoreBundle\Form\Type\ImmutableArrayType'
-                : 'sonata_type_immutable_array',
-            [
+            ImmutableArrayType::class, [
                 'keys' => [
-                    ['title',
-                        // NEXT_MAJOR: remove when dropping Symfony <2.8 support
-                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                            ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-                            : 'text',
-                        [
-                            'label' => 'form.label_title',
-                            'required' => false,
-                        ],
-                    ],
-                    ['context',
-                        // NEXT_MAJOR: remove when dropping Symfony <2.8 support
-                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-                            : 'choice',
-                        [
-                            'label' => 'form.label_context',
-                            'required' => false,
-                            'choices' => $this->getContextChoices(),
-                        ],
-                    ],
+                    ['title', TextType::class, [
+                        'label' => 'form.label_title',
+                        'required' => false,
+                    ]],
+                    ['context', ChoiceType::class, [
+                        'label' => 'form.label_context',
+                        'required' => false,
+                        'choices' => $this->getContextChoices(),
+                    ]],
                     [$adminField, null, []],
                 ],
                 'translation_domain' => 'SonataClassificationBundle',

--- a/Block/Service/AbstractTagsBlockService.php
+++ b/Block/Service/AbstractTagsBlockService.php
@@ -15,12 +15,14 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
-use Sonata\ClassificationBundle\Model\ContextInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 use Sonata\ClassificationBundle\Model\TagInterface;
 use Sonata\ClassificationBundle\Model\TagManagerInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -79,12 +81,6 @@ abstract class AbstractTagsBlockService extends AbstractClassificationBlockServi
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $contextChoices = [];
-        /** @var ContextInterface $context */
-        foreach ($this->contextManager->findAll() as $context) {
-            $contextChoices[$context->getId()] = $context->getName();
-        }
-
         $adminField = $this->getFormAdminType($formMapper, $this->tagAdmin, 'tagId', 'tag', [
             'label' => 'form.label_tag',
         ], [
@@ -96,34 +92,17 @@ abstract class AbstractTagsBlockService extends AbstractClassificationBlockServi
             ],
         ]);
 
-        $formMapper->add('settings',
-            // NEXT_MAJOR: remove when dropping Symfony <2.8 support
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Sonata\CoreBundle\Form\Type\ImmutableArrayType'
-                : 'sonata_type_immutable_array',
-            [
+        $formMapper->add('settings', ImmutableArrayType::class, [
                 'keys' => [
-                    ['title',
-                        // NEXT_MAJOR: remove when dropping Symfony <2.8 support
-                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                            ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-                            : 'text',
-                        [
-                            'label' => 'form.label_title',
-                            'required' => false,
-                        ],
-                    ],
-                    ['context',
-                        // NEXT_MAJOR: remove when dropping Symfony <2.8 support
-                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-                            : 'choice',
-                        [
-                            'label' => 'form.label_context',
-                            'required' => false,
-                            'choices' => $this->getContextChoices(),
-                        ],
-                    ],
+                    ['title', TextType::class, [
+                        'label' => 'form.label_title',
+                        'required' => false,
+                    ]],
+                    ['context', ChoiceType::class, [
+                        'label' => 'form.label_context',
+                        'required' => false,
+                        'choices' => $this->getContextChoices(),
+                    ]],
                     [$adminField, null, []],
                 ],
                 'translation_domain' => 'SonataClassificationBundle',

--- a/Form/Type/CategorySelectorType.php
+++ b/Form/Type/CategorySelectorType.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\ClassificationBundle\Form\Type;
 
+use Sonata\AdminBundle\Form\Type\ModelType;
 use Sonata\ClassificationBundle\Form\ChoiceList\CategoryChoiceLoader;
 use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
@@ -113,10 +114,7 @@ class CategorySelectorType extends AbstractType
      */
     public function getParent()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\ModelType'
-            : 'sonata_type_model';
+        return ModelType::class;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -17,20 +17,20 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^7.1",
         "cocur/slugify": "^1.4 || ^2.0",
         "sonata-project/admin-bundle": "^3.1",
         "sonata-project/core-bundle": "^3.2",
         "sonata-project/datagrid-bundle": "^2.2.1",
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
         "sonata-project/easy-extends-bundle": "^2.2",
-        "symfony/config": "^2.3.9 || ^3.0",
-        "symfony/console": "^2.3 || ^3.0",
-        "symfony/dependency-injection": "^2.3.3 || ^3.0",
-        "symfony/form": "^2.3.5 || ^3.0",
-        "symfony/http-foundation": "^2.3 || ^3.0",
-        "symfony/http-kernel": "^2.3 || ^3.0",
-        "symfony/options-resolver": "^2.3 || ^3.0",
+        "symfony/config": "^2.8 || ^3.2",
+        "symfony/console": "^2.8 || ^3.2",
+        "symfony/dependency-injection": "^2.8 || ^3.2",
+        "symfony/form": "^2.8 || ^3.2",
+        "symfony/http-foundation": "^2.8 || ^3.2",
+        "symfony/http-kernel": "^2.8 || ^3.2",
+        "symfony/options-resolver": "^2.8 || ^3.2",
         "twig/twig": "^1.14.2 || ^2.0"
     },
     "require-dev": {
@@ -39,7 +39,7 @@
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/block-bundle": "^3.3.1",
         "sonata-project/media-bundle": "^3.0",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0"
+        "symfony/phpunit-bridge": "^3.3"
     },
     "suggest": {
         "sonata-project/block-bundle": "For rendering dynamic list blocks on a page.",


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Removed usage of old form type aliases

### Removed
- support for old versions of php and Symfony
```
