### PR TITLE
Fix context association for tag, category or collection

### DIFF
--- a/src/Admin/ContextAwareAdmin.php
+++ b/src/Admin/ContextAwareAdmin.php
@@ -43,21 +43,25 @@ abstract class ContextAwareAdmin extends AbstractAdmin
     {
         $instance = parent::getNewInstance();
 
-        if ($contextId = $this->getPersistentParameter('context')) {
-            $context = $this->contextManager->find($contextId);
-
-            if (!$context) {
-                /** @var ContextInterface $context */
-                $context = $this->contextManager->create();
-                $context->setEnabled(true);
-                $context->setId($contextId);
-                $context->setName($contextId);
-
-                $this->contextManager->save($context);
-            }
-
-            $instance->setContext($context);
+        // Get the context persistent parameter (can be a string, NULL or empty string) and fallback to "default"
+        $contextId = $this->getPersistentParameter('context');
+        if (!strlen($contextId)) {
+            $contextId = ContextInterface::DEFAULT_CONTEXT;
         }
+
+        // Get the existing context or create/persist a new one for this istance
+        $context = $this->contextManager->find($contextId);
+        if (!$context) {
+            /** @var ContextInterface $context */
+            $context = $this->contextManager->create();
+            $context->setId($contextId);
+            $context->setName(ucfirst($contextId));
+            $context->setEnabled(true);
+
+            $this->contextManager->save($context);
+        }
+
+        $instance->setContext($context);
 
         return $instance;
     }


### PR DESCRIPTION
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #359

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Create a new "default" context when creating a new category, tag or collection
```

## Subject

When creating a new tag, collection or category we should create a new context the same way we do in [FixContextCommand](https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/src/Command/FixContextCommand.php#L48).

In particular, creating a new root category without a context "corrupts" the database and people can only recover from that manually editing the database rows (see the issue associated).

**I suggest to merge this after #367 and #368** .