### PR TITLE
Fix deleting a context associated to an entity

### DIFF
--- a/src/DependencyInjection/SonataClassificationExtension.php
+++ b/src/DependencyInjection/SonataClassificationExtension.php
@@ -158,6 +158,7 @@ class SonataClassificationExtension extends Extension
                 [
                     'name' => 'context',
                     'referencedColumnName' => 'id',
+                    'onDelete' => 'SET NULL',
                 ],
             ],
             'orphanRemoval' => false,
@@ -175,6 +176,7 @@ class SonataClassificationExtension extends Extension
                 [
                     'name' => 'context',
                     'referencedColumnName' => 'id',
+                    'onDelete' => 'SET NULL',
                 ],
             ],
             'orphanRemoval' => false,
@@ -194,6 +196,7 @@ class SonataClassificationExtension extends Extension
                 [
                     'name' => 'context',
                     'referencedColumnName' => 'id',
+                    'onDelete' => 'SET NULL',
                 ],
             ],
             'orphanRemoval' => false,


### PR DESCRIPTION
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #361

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `'onDelete' => 'SET NULL'` for mapping from Tag, Collection and Category towards Context
```
## Subject

This fixes the removal of a context associated to a tag, collection or category by setting the foreign key behaviour for column `context` of that entity to `NULL`.