### PR TITLE
Added missing getId method to Context model

### DIFF
--- a/src/Model/Context.php
+++ b/src/Model/Context.php
@@ -122,4 +122,12 @@ abstract class Context implements ContextInterface
     {
         $this->id = $id;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `Context::getId` method
```

## Subject

There is already a `setId` method, but the getter was missing.