### PR TITLE
Remove useless NotNull validation constraint from name property

### DIFF
--- a/src/Resources/config/validation.xml
+++ b/src/Resources/config/validation.xml
@@ -3,7 +3,6 @@
     <class name="Sonata\ClassificationBundle\Model\Category">
         <property name="name">
             <constraint name="NotBlank"/>
-            <constraint name="NotNull"/>
             <constraint name="Length">
                 <option name="min">2</option>
                 <option name="max">32</option>
@@ -13,7 +12,6 @@
     <class name="Sonata\ClassificationBundle\Model\Tag">
         <property name="name">
             <constraint name="NotBlank"/>
-            <constraint name="NotNull"/>
             <constraint name="Length">
                 <option name="min">2</option>
                 <option name="max">32</option>
@@ -26,7 +24,6 @@
     <class name="Sonata\ClassificationBundle\Model\Collection">
         <property name="name">
             <constraint name="NotBlank"/>
-            <constraint name="NotNull"/>
             <constraint name="Length">
                 <option name="min">2</option>
                 <option name="max">32</option>
@@ -39,7 +36,6 @@
     <class name="Sonata\ClassificationBundle\Model\Context">
         <property name="name">
             <constraint name="NotBlank"/>
-            <constraint name="NotNull"/>
             <constraint name="Length">
                 <option name="min">2</option>
                 <option name="max">32</option>


### PR DESCRIPTION
I am targeting this branch, because this is a minor fix.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- `NotNull` validator constraint for each name property.
   (Tag, Context, Category, Collection entities)
```
## Subject

Constraint `NotNull` is not needed when NotBlank is already present:

![cattura](https://user-images.githubusercontent.com/1532616/33774288-17178f64-dc3b-11e7-83be-fde97de2c223.PNG)

