### PR TITLE
Fix context id type hint and validation

### DIFF
--- a/src/Model/Context.php
+++ b/src/Model/Context.php
@@ -14,7 +14,7 @@ namespace Sonata\ClassificationBundle\Model;
 abstract class Context implements ContextInterface
 {
     /**
-     * @var int
+     * @var string
      */
     protected $id;
 

--- a/src/Model/ContextInterface.php
+++ b/src/Model/ContextInterface.php
@@ -44,16 +44,16 @@ interface ContextInterface
     public function getEnabled();
 
     /**
-     * Set slug.
+     * Set id.
      *
-     * @param int $id
+     * @param string $id
      */
     public function setId($id);
 
     /**
-     * Get slug.
+     * Get id.
      *
-     * @return int $slug
+     * @return string $id
      */
     public function getId();
 

--- a/src/Resources/config/validation.xml
+++ b/src/Resources/config/validation.xml
@@ -37,6 +37,9 @@
         </property>
     </class>
     <class name="Sonata\ClassificationBundle\Model\Context">
+        <property name="id">
+            <constraint name="NotBlank"/>
+        </property>
         <property name="name">
             <constraint name="NotBlank"/>
             <constraint name="NotNull"/>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a minor fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- NotBlank constraint: context id property is now required
```

## Subject
Context id should be a string, type hint is wrong in both `Context ` and `ContextInterface`. Property id is missing the `NotBlank` validation constraint.

Without the constraint when you create a new context and forget to set the id, an exception is thrown. #