### PR TITLE
Make the context foreign key not nullable in Tag entity

### DIFF
--- a/src/DependencyInjection/SonataClassificationExtension.php
+++ b/src/DependencyInjection/SonataClassificationExtension.php
@@ -175,6 +175,8 @@ class SonataClassificationExtension extends Extension
                 [
                     'name' => 'context',
                     'referencedColumnName' => 'id',
+                    'nullable' => false,
+                    'onDelete' => 'CASCADE',
                 ],
             ],
             'orphanRemoval' => false,


### PR DESCRIPTION
I am targeting this branch, because this is an enhancement.

Closes #366

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Column `context` for entity Tag is now not nullable
- When you delete a context all tags that belongs to that context are removed
```

## Subject
A tag cannot be created without a context. So context column should be `NOT NULL` and delete behaviour should be `ON DELETE CASCADE`.