### PR TITLE
Make the context foreign key not nullable in Collection entity

### DIFF
--- a/src/DependencyInjection/SonataClassificationExtension.php
+++ b/src/DependencyInjection/SonataClassificationExtension.php
@@ -194,6 +194,8 @@ class SonataClassificationExtension extends Extension
                 [
                     'name' => 'context',
                     'referencedColumnName' => 'id',
+                    'nullable' => false,
+                    'onDelete' => 'CASCADE',
                 ],
             ],
             'orphanRemoval' => false,


### PR DESCRIPTION
I am targeting this branch, because this is an enhancement.

Similar of #367.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Column `context` for entity Collection is now not nullable
- When you delete a context all collections that belongs to that context are removed
```

## Subject
A collection cannot be created without a context. So context column should be `NOT NULL` and delete behaviour should be `ON DELETE CASCADE`.