### PR TITLE
Use FormRenderer runtime to maintain compatibility with Symfony 3.4

### DIFF
--- a/src/Controller/CategoryAdminController.php
+++ b/src/Controller/CategoryAdminController.php
@@ -12,6 +12,11 @@
 namespace Sonata\ClassificationBundle\Controller;
 
 use Sonata\AdminBundle\Controller\CRUDController as Controller;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Command\DebugCommand;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -131,12 +136,19 @@ class CategoryAdminController extends Controller
         $twig = $this->get('twig');
 
         // BC for Symfony < 3.2 where this runtime does not exists
-        if (!method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
-            $twig->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')
-                ->renderer->setTheme($formView, $theme);
+        if (!method_exists(AppVariable::class, 'getToken')) {
+            $twig->getExtension(FormExtension::class)->renderer->setTheme($formView, $theme);
 
             return;
         }
-        $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->setTheme($formView, $theme);
+
+        // BC for Symfony < 3.4 where runtime should be TwigRenderer
+        if (!method_exists(DebugCommand::class, 'getLoaderPaths')) {
+            $twig->getRuntime(TwigRenderer::class)->setTheme($formView, $theme);
+
+            return;
+        }
+
+        $twig->getRuntime(FormRenderer::class)->setTheme($formView, $theme);
     }
 }

--- a/tests/Controller/CategoryAdminControllerTest.php
+++ b/tests/Controller/CategoryAdminControllerTest.php
@@ -17,7 +17,11 @@ use Sonata\AdminBundle\Admin\Pool;
 use Sonata\ClassificationBundle\Controller\CategoryAdminController;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Command\DebugCommand;
 use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
 use Symfony\Component\Form\FormView;
@@ -129,13 +133,22 @@ class CategoryAdminControllerTest extends TestCase
         $pool = $this->pool;
         $request = $this->request;
 
-        $twig = $this->getMockBuilder('Twig_Environment')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $twig = $this->createMock(\Twig_Environment::class);
 
-        $twigRenderer = $this->createMock('Symfony\Bridge\Twig\Form\TwigRendererInterface');
+        // Remove this trick when bumping Symfony requirement to 3.4+
+        if (method_exists(DebugCommand::class, 'getLoaderPaths')) {
+            $rendererClass = FormRenderer::class;
+        } else {
+            $rendererClass = TwigRenderer::class;
+        }
+
+        $twigRenderer = $this->createMock($rendererClass);
 
         $formExtension = new FormExtension($twigRenderer);
+
+        if (!method_exists(AppVariable::class, 'getToken')) {
+            $formExtension->renderer = $formExtension;
+        }
 
         $twig->expects($this->any())
             ->method('getExtension')


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it fixes a bug (Admin controllers do not work with Symfony 3.4)

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Use FormRenderer runtime to maintain compatibility with Symfony 3.4
```


## Subject

<!-- Describe your Pull Request content here -->

Symfony 3.4 deprecates `TwigRenderer` (TwigBridge) in favour of `FormRenderer` (Form component). While the old class is still available, it is not registered as a Twig runtime anymore. ([See this related changeset in the TwigBridge component.](https://github.com/symfony/symfony/pull/23437/files#diff-5eb0532c96734f6e23428e921225b2f0))