### PR TITLE
Allow Slugify 3.0 and higher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "cocur/slugify": "^1.4 || ^2.0",
+        "cocur/slugify": "^1.4 || ^2.0 || ^3.0",
         "sonata-project/admin-bundle": "^3.1",
         "sonata-project/core-bundle": "^3.2",
         "sonata-project/datagrid-bundle": "^2.2.1",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it causes no BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #374

## Changelog

Make the bundle compatible with Slugify ^3.0

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
Slugify dependency 
```
## Subject

Add ^3.0 as compatible Slugify version so people who use SonataClassificationBundle can also use Slugify in version 3.0 and higher

<!-- Describe your Pull Request content here -->
