### PR TITLE
Replace FQCN strings with ::class constants, Fix tests for SF 4

### DIFF
--- a/src/Admin/CategoryAdmin.php
+++ b/src/Admin/CategoryAdmin.php
@@ -17,6 +17,7 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\ClassificationBundle\Form\Type\CategorySelectorType;
+use Sonata\MediaBundle\Model\MediaInterface;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -99,7 +100,7 @@ EOT
             ->end()
         ;
 
-        if (interface_exists('Sonata\MediaBundle\Model\MediaInterface')) {
+        if (interface_exists(MediaInterface::class)) {
             $formMapper
                 ->with('General')
                     ->add('media', ModelListType::class, [

--- a/src/Admin/CollectionAdmin.php
+++ b/src/Admin/CollectionAdmin.php
@@ -15,6 +15,7 @@ use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Form\Type\ModelListType;
+use Sonata\MediaBundle\Model\MediaInterface;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Validator\Constraints\Valid;
@@ -62,7 +63,7 @@ EOT
             ])
         ;
 
-        if (interface_exists('Sonata\MediaBundle\Model\MediaInterface')) {
+        if (interface_exists(MediaInterface::class)) {
             $formMapper->add('media', ModelListType::class, [
                 'required' => false,
             ], [

--- a/src/Controller/Api/CategoryController.php
+++ b/src/Controller/Api/CategoryController.php
@@ -256,7 +256,7 @@ class CategoryController
 
             $view = FOSRestView::create($category);
 
-            if (class_exists('FOS\RestBundle\Context\Context')) {
+            if (class_exists(Context::class)) {
                 $context = new Context();
                 $context->setGroups(['sonata_api_read']);
                 $view->setContext($context);

--- a/src/Controller/Api/CollectionController.php
+++ b/src/Controller/Api/CollectionController.php
@@ -255,7 +255,7 @@ class CollectionController
 
             $view = FOSRestView::create($collection);
 
-            if (class_exists('FOS\RestBundle\Context\Context')) {
+            if (class_exists(Context::class)) {
                 $context = new Context();
                 $context->setGroups(['sonata_api_read']);
                 $view->setContext($context);

--- a/src/Controller/Api/ContextController.php
+++ b/src/Controller/Api/ContextController.php
@@ -255,7 +255,7 @@ class ContextController
 
             $view = FOSRestView::create($context);
 
-            if (class_exists('FOS\RestBundle\Context\Context')) {
+            if (class_exists(Context::class)) {
                 $context = new Context();
                 $context->setGroups(['sonata_api_read']);
                 $view->setContext($context);

--- a/src/Controller/Api/TagController.php
+++ b/src/Controller/Api/TagController.php
@@ -255,7 +255,7 @@ class TagController
 
             $view = FOSRestView::create($tag);
 
-            if (class_exists('FOS\RestBundle\Context\Context')) {
+            if (class_exists(Context::class)) {
                 $context = new Context();
                 $context->setGroups(['sonata_api_read']);
                 $view->setContext($context);

--- a/src/Controller/CategoryAdminController.php
+++ b/src/Controller/CategoryAdminController.php
@@ -12,6 +12,11 @@
 namespace Sonata\ClassificationBundle\Controller;
 
 use Sonata\AdminBundle\Controller\CRUDController as Controller;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Command\DebugCommand;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -131,12 +136,19 @@ class CategoryAdminController extends Controller
         $twig = $this->get('twig');
 
         // BC for Symfony < 3.2 where this runtime does not exists
-        if (!method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
-            $twig->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')
+        if (!method_exists(AppVariable::class, 'getToken')) {
+            $twig->getExtension(FormExtension::class)
                 ->renderer->setTheme($formView, $theme);
 
             return;
         }
-        $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->setTheme($formView, $theme);
+
+        // BC for Symfony < 3.4 where runtime should be TwigRenderer
+        if (!method_exists(DebugCommand::class, 'getLoaderPaths')) {
+            $twig->getRuntime(TwigRenderer::class)->setTheme($formView, $theme);
+
+            return;
+        }
+        $twig->getRuntime(FormRenderer::class)->setTheme($formView, $theme);
     }
 }

--- a/src/DependencyInjection/SonataClassificationExtension.php
+++ b/src/DependencyInjection/SonataClassificationExtension.php
@@ -12,6 +12,7 @@
 namespace Sonata\ClassificationBundle\DependencyInjection;
 
 use Sonata\EasyExtendsBundle\Mapper\DoctrineCollector;
+use Sonata\MediaBundle\Model\MediaInterface;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -201,7 +202,7 @@ class SonataClassificationExtension extends Extension
 
         $collector->addUnique($config['class']['collection'], 'tag_collection', ['slug', 'context']);
 
-        if (interface_exists('Sonata\MediaBundle\Model\MediaInterface')) {
+        if (interface_exists(MediaInterface::class)) {
             $collector->addAssociation($config['class']['collection'], 'mapManyToOne', [
                 'fieldName' => 'media',
                 'targetEntity' => $config['class']['media'],

--- a/src/Form/Type/CategorySelectorType.php
+++ b/src/Form/Type/CategorySelectorType.php
@@ -17,6 +17,7 @@ use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\CoreBundle\Model\ManagerInterface;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -61,7 +62,7 @@ class CategorySelectorType extends AbstractType
     {
         $that = $this;
 
-        if (!interface_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')) {
+        if (!interface_exists(ChoiceLoaderInterface::class)) {
             $resolver->setDefaults([
                 'context' => null,
                 'category' => null,

--- a/src/SonataClassificationBundle.php
+++ b/src/SonataClassificationBundle.php
@@ -11,6 +11,11 @@
 
 namespace Sonata\ClassificationBundle;
 
+use Sonata\ClassificationBundle\Form\Type\ApiCategoryType;
+use Sonata\ClassificationBundle\Form\Type\ApiCollectionType;
+use Sonata\ClassificationBundle\Form\Type\ApiContextType;
+use Sonata\ClassificationBundle\Form\Type\ApiTagType;
+use Sonata\ClassificationBundle\Form\Type\CategorySelectorType;
 use Sonata\CoreBundle\Form\FormHelper;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -39,11 +44,11 @@ class SonataClassificationBundle extends Bundle
     public function registerFormMapping()
     {
         FormHelper::registerFormTypeMapping([
-            'sonata_classification_api_form_category' => 'Sonata\ClassificationBundle\Form\Type\ApiCategoryType',
-            'sonata_classification_api_form_collection' => 'Sonata\ClassificationBundle\Form\Type\ApiCollectionType',
-            'sonata_classification_api_form_tag' => 'Sonata\ClassificationBundle\Form\Type\ApiTagType',
-            'sonata_classification_api_form_context' => 'Sonata\ClassificationBundle\Form\Type\ApiContextType',
-            'sonata_category_selector' => 'Sonata\ClassificationBundle\Form\Type\CategorySelectorType',
+            'sonata_classification_api_form_category' => ApiCategoryType::class,
+            'sonata_classification_api_form_collection' => ApiCollectionType::class,
+            'sonata_classification_api_form_tag' => ApiTagType::class,
+            'sonata_classification_api_form_context' => ApiContextType::class,
+            'sonata_category_selector' => CategorySelectorType::class,
         ]);
     }
 }

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -12,6 +12,10 @@
 namespace Sonata\ClassificationBundle\Tests\Admin;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\AdminExtensionInterface;
+use Sonata\ClassificationBundle\Admin\ContextAdmin;
+use Sonata\ClassificationBundle\Admin\ContextAwareAdmin;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 
 class AdminTest extends TestCase
@@ -23,19 +27,15 @@ class AdminTest extends TestCase
 
     public function setUp()
     {
-        $this->contextManager = $this->createMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $this->contextManager = $this->createMock(ContextManagerInterface::class);
     }
 
     public function testAbstractAdminChildren()
     {
-        $contextAwareAdmin = $this->getMockBuilder('Sonata\ClassificationBundle\Admin\ContextAwareAdmin')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->assertInstanceOf('Sonata\AdminBundle\Admin\AbstractAdmin', $contextAwareAdmin);
-        $contextAdmin = $this->getMockBuilder('Sonata\ClassificationBundle\Admin\ContextAdmin')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->assertInstanceOf('Sonata\AdminBundle\Admin\AbstractAdmin', $contextAdmin);
+        $contextAwareAdmin = $this->createMock(ContextAwareAdmin::class);
+        $this->assertInstanceOf(AbstractAdmin::class, $contextAwareAdmin);
+        $contextAdmin = $this->createMock(ContextAdmin::class);
+        $this->assertInstanceOf(AbstractAdmin::class, $contextAdmin);
     }
 
     public function testGetPersistentParametersWithNoExtension()
@@ -45,7 +45,7 @@ class AdminTest extends TestCase
             'hide_context' => 0,
         ];
 
-        $admin = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Admin\ContextAwareAdmin', [
+        $admin = $this->getMockForAbstractClass(ContextAwareAdmin::class, [
             'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin', $this->contextManager,
         ]);
 
@@ -56,11 +56,11 @@ class AdminTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $admin = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Admin\ContextAwareAdmin', [
+        $admin = $this->getMockForAbstractClass(ContextAwareAdmin::class, [
             'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin', $this->contextManager,
         ]);
 
-        $extension = $this->createMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
+        $extension = $this->createMock(AdminExtensionInterface::class);
         $extension->expects($this->once())->method('getPersistentParameters')->will($this->returnValue(null));
 
         $admin->addExtension($extension);
@@ -82,11 +82,11 @@ class AdminTest extends TestCase
             'abc' => 123,
         ];
 
-        $admin = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Admin\ContextAwareAdmin', [
+        $admin = $this->getMockForAbstractClass(ContextAwareAdmin::class, [
             'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin', $this->contextManager,
         ]);
 
-        $extension = $this->createMock('Sonata\AdminBundle\Admin\AdminExtensionInterface');
+        $extension = $this->createMock(AdminExtensionInterface::class);
         $extension->expects($this->once())->method('getPersistentParameters')->will($this->returnValue($extensionParams));
 
         $admin->addExtension($extension);

--- a/tests/Block/Service/AbstractCategoriesBlockServiceTest.php
+++ b/tests/Block/Service/AbstractCategoriesBlockServiceTest.php
@@ -11,9 +11,12 @@
 
 namespace Sonata\ClassificationBundle\Tests\Block\Service;
 
+use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 use Sonata\BlockBundle\Test\FakeTemplating;
 use Sonata\ClassificationBundle\Admin\CategoryAdmin;
+use Sonata\ClassificationBundle\Block\Service\AbstractCategoriesBlockService;
+use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 
@@ -42,14 +45,14 @@ final class AbstractCategoriesBlockServiceTest extends AbstractBlockServiceTestC
         parent::setUp();
 
         $this->templating = new FakeTemplating();
-        $this->contextManager = $this->createMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
-        $this->categoryManager = $this->createMock('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
-        $this->categoryAdmin = $this->getMockBuilder('Sonata\ClassificationBundle\Admin\CategoryAdmin')->disableOriginalConstructor()->getMock();
+        $this->contextManager = $this->createMock(ContextManagerInterface::class);
+        $this->categoryManager = $this->createMock(CategoryManagerInterface::class);
+        $this->categoryAdmin = $this->createMock(CategoryAdmin::class);
     }
 
     public function testDefaultSettings()
     {
-        $blockService = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Block\Service\AbstractCategoriesBlockService', [
+        $blockService = $this->getMockForAbstractClass(AbstractCategoriesBlockService::class, [
             'block.service', $this->templating, $this->contextManager, $this->categoryManager, $this->categoryAdmin,
         ]);
         $blockContext = $this->getBlockContext($blockService);
@@ -65,7 +68,7 @@ final class AbstractCategoriesBlockServiceTest extends AbstractBlockServiceTestC
 
     public function testLoad()
     {
-        $category = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CategoryInterface')
+        $category = $this->getMockBuilder(CategoryInterface::class)
             ->setMethods(['getId'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
@@ -76,7 +79,7 @@ final class AbstractCategoriesBlockServiceTest extends AbstractBlockServiceTestC
             ->with($this->equalTo('23'))
             ->will($this->returnValue($category));
 
-        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock(BlockInterface::class);
         $block->expects($this->any())
             ->method('getSetting')
             ->with($this->equalTo('categoryId'))
@@ -85,7 +88,7 @@ final class AbstractCategoriesBlockServiceTest extends AbstractBlockServiceTestC
             ->method('setSetting')
             ->with($this->equalTo('categoryId'), $this->equalTo($category));
 
-        $blockService = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Block\Service\AbstractCategoriesBlockService', [
+        $blockService = $this->getMockForAbstractClass(AbstractCategoriesBlockService::class, [
             'block.service', $this->templating, $this->contextManager, $this->categoryManager, $this->categoryAdmin,
         ]);
         $blockService->load($block);
@@ -93,13 +96,13 @@ final class AbstractCategoriesBlockServiceTest extends AbstractBlockServiceTestC
 
     public function testPrePersist()
     {
-        $category = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CategoryInterface')
+        $category = $this->getMockBuilder(CategoryInterface::class)
             ->setMethods(['getId'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $category->expects($this->any())->method('getId')->will($this->returnValue(23));
 
-        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock(BlockInterface::class);
         $block->expects($this->any())
             ->method('getSetting')
             ->with($this->equalTo('categoryId'))
@@ -108,7 +111,7 @@ final class AbstractCategoriesBlockServiceTest extends AbstractBlockServiceTestC
             ->method('setSetting')
             ->with($this->equalTo('categoryId'), $this->equalTo(23));
 
-        $blockService = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Block\Service\AbstractCategoriesBlockService', [
+        $blockService = $this->getMockForAbstractClass(AbstractCategoriesBlockService::class, [
             'block.service', $this->templating, $this->contextManager, $this->categoryManager, $this->categoryAdmin,
         ]);
         $blockService->prePersist($block);
@@ -116,13 +119,13 @@ final class AbstractCategoriesBlockServiceTest extends AbstractBlockServiceTestC
 
     public function testPreUpdate()
     {
-        $category = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CategoryInterface')
+        $category = $this->getMockBuilder(CategoryInterface::class)
             ->setMethods(['getId'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $category->expects($this->any())->method('getId')->will($this->returnValue(23));
 
-        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock(BlockInterface::class);
         $block->expects($this->any())
             ->method('getSetting')
             ->with($this->equalTo('categoryId'))
@@ -131,7 +134,7 @@ final class AbstractCategoriesBlockServiceTest extends AbstractBlockServiceTestC
             ->method('setSetting')
             ->with($this->equalTo('categoryId'), $this->equalTo(23));
 
-        $blockService = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Block\Service\AbstractCategoriesBlockService', [
+        $blockService = $this->getMockForAbstractClass(AbstractCategoriesBlockService::class, [
             'block.service', $this->templating, $this->contextManager, $this->categoryManager, $this->categoryAdmin,
         ]);
         $blockService->preUpdate($block);

--- a/tests/Block/Service/AbstractCollectionsBlockServiceTest.php
+++ b/tests/Block/Service/AbstractCollectionsBlockServiceTest.php
@@ -11,9 +11,12 @@
 
 namespace Sonata\ClassificationBundle\Tests\Block\Service;
 
+use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 use Sonata\BlockBundle\Test\FakeTemplating;
 use Sonata\ClassificationBundle\Admin\CollectionAdmin;
+use Sonata\ClassificationBundle\Block\Service\AbstractCollectionsBlockService;
+use Sonata\ClassificationBundle\Model\CollectionInterface;
 use Sonata\ClassificationBundle\Model\CollectionManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 
@@ -42,14 +45,14 @@ final class AbstractCollectionsBlockServiceTest extends AbstractBlockServiceTest
         parent::setUp();
 
         $this->templating = new FakeTemplating();
-        $this->contextManager = $this->createMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
-        $this->collectionManager = $this->createMock('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
-        $this->collectionAdmin = $this->getMockBuilder('Sonata\ClassificationBundle\Admin\CollectionAdmin')->disableOriginalConstructor()->getMock();
+        $this->contextManager = $this->createMock(ContextManagerInterface::class);
+        $this->collectionManager = $this->createMock(CollectionManagerInterface::class);
+        $this->collectionAdmin = $this->createMock(CollectionAdmin::class);
     }
 
     public function testDefaultSettings()
     {
-        $blockService = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Block\Service\AbstractCollectionsBlockService', [
+        $blockService = $this->getMockForAbstractClass(AbstractCollectionsBlockService::class, [
             'block.service', $this->templating, $this->contextManager, $this->collectionManager, $this->collectionAdmin,
         ]);
         $blockContext = $this->getBlockContext($blockService);
@@ -65,7 +68,7 @@ final class AbstractCollectionsBlockServiceTest extends AbstractBlockServiceTest
 
     public function testLoad()
     {
-        $collection = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CollectionInterface')
+        $collection = $this->getMockBuilder(CollectionInterface::class)
             ->setMethods(['getId'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
@@ -76,7 +79,7 @@ final class AbstractCollectionsBlockServiceTest extends AbstractBlockServiceTest
             ->with($this->equalTo('23'))
             ->will($this->returnValue($collection));
 
-        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock(BlockInterface::class);
         $block->expects($this->any())
             ->method('getSetting')
             ->with($this->equalTo('collectionId'))
@@ -85,7 +88,7 @@ final class AbstractCollectionsBlockServiceTest extends AbstractBlockServiceTest
             ->method('setSetting')
             ->with($this->equalTo('collectionId'), $this->equalTo($collection));
 
-        $blockService = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Block\Service\AbstractCollectionsBlockService', [
+        $blockService = $this->getMockForAbstractClass(AbstractCollectionsBlockService::class, [
             'block.service', $this->templating, $this->contextManager, $this->collectionManager, $this->collectionAdmin,
         ]);
         $blockService->load($block);
@@ -93,13 +96,13 @@ final class AbstractCollectionsBlockServiceTest extends AbstractBlockServiceTest
 
     public function testPrePersist()
     {
-        $collection = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CollectionInterface')
+        $collection = $this->getMockBuilder(CollectionInterface::class)
             ->setMethods(['getId'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $collection->expects($this->any())->method('getId')->will($this->returnValue(23));
 
-        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock(BlockInterface::class);
         $block->expects($this->any())
             ->method('getSetting')
             ->with($this->equalTo('collectionId'))
@@ -108,7 +111,7 @@ final class AbstractCollectionsBlockServiceTest extends AbstractBlockServiceTest
             ->method('setSetting')
             ->with($this->equalTo('collectionId'), $this->equalTo(23));
 
-        $blockService = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Block\Service\AbstractCollectionsBlockService', [
+        $blockService = $this->getMockForAbstractClass(AbstractCollectionsBlockService::class, [
             'block.service', $this->templating, $this->contextManager, $this->collectionManager, $this->collectionAdmin,
         ]);
         $blockService->prePersist($block);
@@ -116,13 +119,13 @@ final class AbstractCollectionsBlockServiceTest extends AbstractBlockServiceTest
 
     public function testPreUpdate()
     {
-        $collection = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CollectionInterface')
+        $collection = $this->getMockBuilder(CollectionInterface::class)
             ->setMethods(['getId'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $collection->expects($this->any())->method('getId')->will($this->returnValue(23));
 
-        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock(BlockInterface::class);
         $block->expects($this->any())
             ->method('getSetting')
             ->with($this->equalTo('collectionId'))
@@ -131,7 +134,7 @@ final class AbstractCollectionsBlockServiceTest extends AbstractBlockServiceTest
             ->method('setSetting')
             ->with($this->equalTo('collectionId'), $this->equalTo(23));
 
-        $blockService = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Block\Service\AbstractCollectionsBlockService', [
+        $blockService = $this->getMockForAbstractClass(AbstractCollectionsBlockService::class, [
             'block.service', $this->templating, $this->contextManager, $this->collectionManager, $this->collectionAdmin,
         ]);
         $blockService->preUpdate($block);

--- a/tests/Block/Service/AbstractTagsBlockServiceTest.php
+++ b/tests/Block/Service/AbstractTagsBlockServiceTest.php
@@ -11,10 +11,13 @@
 
 namespace Sonata\ClassificationBundle\Tests\Block\Service;
 
-use Sonata\AdminBundle\Tests\Fixtures\Admin\TagAdmin;
+use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 use Sonata\BlockBundle\Test\FakeTemplating;
+use Sonata\ClassificationBundle\Admin\TagAdmin;
+use Sonata\ClassificationBundle\Block\Service\AbstractTagsBlockService;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
+use Sonata\ClassificationBundle\Model\TagInterface;
 use Sonata\ClassificationBundle\Model\TagManagerInterface;
 
 /**
@@ -42,14 +45,14 @@ final class AbstractTagsBlockServiceTest extends AbstractBlockServiceTestCase
         parent::setUp();
 
         $this->templating = new FakeTemplating();
-        $this->contextManager = $this->createMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
-        $this->tagManager = $this->createMock('Sonata\ClassificationBundle\Model\TagManagerInterface');
-        $this->tagAdmin = $this->getMockBuilder('Sonata\ClassificationBundle\Admin\TagAdmin')->disableOriginalConstructor()->getMock();
+        $this->contextManager = $this->createMock(ContextManagerInterface::class);
+        $this->tagManager = $this->createMock(TagManagerInterface::class);
+        $this->tagAdmin = $this->createMock(TagAdmin::class);
     }
 
     public function testDefaultSettings()
     {
-        $blockService = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Block\Service\AbstractTagsBlockService', [
+        $blockService = $this->getMockForAbstractClass(AbstractTagsBlockService::class, [
             'block.service', $this->templating, $this->contextManager, $this->tagManager, $this->tagAdmin,
         ]);
         $blockContext = $this->getBlockContext($blockService);
@@ -65,7 +68,7 @@ final class AbstractTagsBlockServiceTest extends AbstractBlockServiceTestCase
 
     public function testLoad()
     {
-        $tag = $this->getMockBuilder('Sonata\ClassificationBundle\Model\TagInterface')
+        $tag = $this->getMockBuilder(TagInterface::class)
             ->setMethods(['getId'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
@@ -76,7 +79,7 @@ final class AbstractTagsBlockServiceTest extends AbstractBlockServiceTestCase
             ->with($this->equalTo('23'))
             ->will($this->returnValue($tag));
 
-        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock(BlockInterface::class);
         $block->expects($this->any())
             ->method('getSetting')
             ->with($this->equalTo('tagId'))
@@ -85,7 +88,7 @@ final class AbstractTagsBlockServiceTest extends AbstractBlockServiceTestCase
             ->method('setSetting')
             ->with($this->equalTo('tagId'), $this->equalTo($tag));
 
-        $blockService = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Block\Service\AbstractTagsBlockService', [
+        $blockService = $this->getMockForAbstractClass(AbstractTagsBlockService::class, [
             'block.service', $this->templating, $this->contextManager, $this->tagManager, $this->tagAdmin,
         ]);
         $blockService->load($block);
@@ -93,13 +96,13 @@ final class AbstractTagsBlockServiceTest extends AbstractBlockServiceTestCase
 
     public function testPrePersist()
     {
-        $tag = $this->getMockBuilder('Sonata\ClassificationBundle\Model\TagInterface')
+        $tag = $this->getMockBuilder(TagInterface::class)
             ->setMethods(['getId'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $tag->expects($this->any())->method('getId')->will($this->returnValue(23));
 
-        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock(BlockInterface::class);
         $block->expects($this->any())
             ->method('getSetting')
             ->with($this->equalTo('tagId'))
@@ -108,7 +111,7 @@ final class AbstractTagsBlockServiceTest extends AbstractBlockServiceTestCase
             ->method('setSetting')
             ->with($this->equalTo('tagId'), $this->equalTo(23));
 
-        $blockService = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Block\Service\AbstractTagsBlockService', [
+        $blockService = $this->getMockForAbstractClass(AbstractTagsBlockService::class, [
             'block.service', $this->templating, $this->contextManager, $this->tagManager, $this->tagAdmin,
         ]);
         $blockService->prePersist($block);
@@ -116,13 +119,13 @@ final class AbstractTagsBlockServiceTest extends AbstractBlockServiceTestCase
 
     public function testPreUpdate()
     {
-        $tag = $this->getMockBuilder('Sonata\ClassificationBundle\Model\TagInterface')
+        $tag = $this->getMockBuilder(TagInterface::class)
             ->setMethods(['getId'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $tag->expects($this->any())->method('getId')->will($this->returnValue(23));
 
-        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock(BlockInterface::class);
         $block->expects($this->any())
             ->method('getSetting')
             ->with($this->equalTo('tagId'))
@@ -131,7 +134,7 @@ final class AbstractTagsBlockServiceTest extends AbstractBlockServiceTestCase
             ->method('setSetting')
             ->with($this->equalTo('tagId'), $this->equalTo(23));
 
-        $blockService = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Block\Service\AbstractTagsBlockService', [
+        $blockService = $this->getMockForAbstractClass(AbstractTagsBlockService::class, [
             'block.service', $this->templating, $this->contextManager, $this->tagManager, $this->tagAdmin,
         ]);
         $blockService->preUpdate($block);

--- a/tests/Controller/Api/CategoryControllerTest.php
+++ b/tests/Controller/Api/CategoryControllerTest.php
@@ -11,9 +11,18 @@
 
 namespace Sonata\ClassificationBundle\Tests\Controller\Api;
 
+use FOS\RestBundle\Request\ParamFetcherInterface;
+use FOS\RestBundle\View\View;
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Datagrid\Pager;
 use Sonata\ClassificationBundle\Controller\Api\CategoryController;
+use Sonata\ClassificationBundle\Model\CategoryInterface;
+use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * @author Vincent Composieux <vincent.composieux@gmail.com>
@@ -22,12 +31,12 @@ class CategoryControllerTest extends TestCase
 {
     public function testGetCategoriesAction()
     {
-        $paramFetcher = $this->createMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->createMock(ParamFetcherInterface::class);
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue([]));
 
-        $pager = $this->getMockBuilder('Sonata\AdminBundle\Datagrid\Pager')->disableOriginalConstructor()->getMock();
+        $pager = $this->createMock(Pager::class);
 
-        $categoryManager = $this->createMock('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
+        $categoryManager = $this->createMock(CategoryManagerInterface::class);
         $categoryManager->expects($this->once())->method('getPager')->will($this->returnValue($pager));
 
         $this->assertSame($pager, $this->createCategoryController($categoryManager)->getCategoriesAction($paramFetcher));
@@ -35,9 +44,9 @@ class CategoryControllerTest extends TestCase
 
     public function testGetCategoryAction()
     {
-        $category = $this->createMock('Sonata\ClassificationBundle\Model\CategoryInterface');
+        $category = $this->createMock(CategoryInterface::class);
 
-        $categoryManager = $this->createMock('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
+        $categoryManager = $this->createMock(CategoryManagerInterface::class);
         $categoryManager->expects($this->once())->method('find')->will($this->returnValue($category));
 
         $this->assertEquals($category, $this->createCategoryController($categoryManager)->getCategoryAction(1));
@@ -45,7 +54,7 @@ class CategoryControllerTest extends TestCase
 
     public function testGetCategoryNotFoundExceptionAction()
     {
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Category (42) not found');
 
         $this->createCategoryController()->getCategoryAction(42);
@@ -53,91 +62,91 @@ class CategoryControllerTest extends TestCase
 
     public function testPostCategoryAction()
     {
-        $category = $this->createMock('Sonata\ClassificationBundle\Model\CategoryInterface');
+        $category = $this->createMock(CategoryInterface::class);
 
-        $categoryManager = $this->createMock('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
+        $categoryManager = $this->createMock(CategoryManagerInterface::class);
         $categoryManager->expects($this->once())->method('save')->will($this->returnValue($category));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($category));
         $form->expects($this->once())->method('all')->will($this->returnValue([]));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCategoryController($categoryManager, $formFactory)->postCategoryAction(new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPostCategoryInvalidAction()
     {
-        $categoryManager = $this->createMock('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
+        $categoryManager = $this->createMock(CategoryManagerInterface::class);
         $categoryManager->expects($this->never())->method('save')->will($this->returnValue($categoryManager));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->once())->method('all')->will($this->returnValue([]));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCategoryController($categoryManager, $formFactory)->postCategoryAction(new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testPutCategoryAction()
     {
-        $category = $this->createMock('Sonata\ClassificationBundle\Model\CategoryInterface');
+        $category = $this->createMock(CategoryInterface::class);
 
-        $categoryManager = $this->createMock('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
+        $categoryManager = $this->createMock(CategoryManagerInterface::class);
         $categoryManager->expects($this->once())->method('find')->will($this->returnValue($category));
         $categoryManager->expects($this->once())->method('save')->will($this->returnValue($category));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($category));
         $form->expects($this->once())->method('all')->will($this->returnValue([]));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCategoryController($categoryManager, $formFactory)->putCategoryAction(1, new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPutPostInvalidAction()
     {
-        $category = $this->createMock('Sonata\ClassificationBundle\Model\CategoryInterface');
+        $category = $this->createMock(CategoryInterface::class);
 
-        $categoryManager = $this->createMock('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
+        $categoryManager = $this->createMock(CategoryManagerInterface::class);
         $categoryManager->expects($this->once())->method('find')->will($this->returnValue($category));
         $categoryManager->expects($this->never())->method('save')->will($this->returnValue($category));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->once())->method('all')->will($this->returnValue([]));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCategoryController($categoryManager, $formFactory)->putCategoryAction(1, new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testDeleteCategoryAction()
     {
-        $category = $this->createMock('Sonata\ClassificationBundle\Model\CategoryInterface');
+        $category = $this->createMock(CategoryInterface::class);
 
-        $categoryManager = $this->createMock('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
+        $categoryManager = $this->createMock(CategoryManagerInterface::class);
         $categoryManager->expects($this->once())->method('find')->will($this->returnValue($category));
         $categoryManager->expects($this->once())->method('delete');
 
@@ -148,9 +157,9 @@ class CategoryControllerTest extends TestCase
 
     public function testDeleteCategoryInvalidAction()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException(NotFoundHttpException::class);
 
-        $categoryManager = $this->createMock('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
+        $categoryManager = $this->createMock(CategoryManagerInterface::class);
         $categoryManager->expects($this->once())->method('find')->will($this->returnValue(null));
         $categoryManager->expects($this->never())->method('delete');
 
@@ -168,10 +177,10 @@ class CategoryControllerTest extends TestCase
     protected function createCategoryController($categoryManager = null, $formFactory = null)
     {
         if (null === $categoryManager) {
-            $categoryManager = $this->createMock('Sonata\ClassificationBundle\Model\CategoryManagerInterface');
+            $categoryManager = $this->createMock(CategoryManagerInterface::class);
         }
         if (null === $formFactory) {
-            $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+            $formFactory = $this->createMock(FormFactoryInterface::class);
         }
 
         return new CategoryController($categoryManager, $formFactory);

--- a/tests/Controller/Api/CollectionControllerTest.php
+++ b/tests/Controller/Api/CollectionControllerTest.php
@@ -11,9 +11,18 @@
 
 namespace Sonata\ClassificationBundle\Tests\Controller\Api;
 
+use FOS\RestBundle\Request\ParamFetcherInterface;
+use FOS\RestBundle\View\View;
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Datagrid\Pager;
 use Sonata\ClassificationBundle\Controller\Api\CollectionController;
+use Sonata\ClassificationBundle\Model\CollectionInterface;
+use Sonata\ClassificationBundle\Model\CollectionManagerInterface;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * @author Vincent Composieux <vincent.composieux@gmail.com>
@@ -22,12 +31,12 @@ class CollectionControllerTest extends TestCase
 {
     public function testGetCollectionsAction()
     {
-        $paramFetcher = $this->createMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->createMock(ParamFetcherInterface::class);
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue([]));
 
-        $pager = $this->getMockBuilder('Sonata\AdminBundle\Datagrid\Pager')->disableOriginalConstructor()->getMock();
+        $pager = $this->createMock(Pager::class);
 
-        $collectionManager = $this->createMock('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
+        $collectionManager = $this->createMock(CollectionManagerInterface::class);
         $collectionManager->expects($this->once())->method('getPager')->will($this->returnValue($pager));
 
         $this->assertSame($pager, $this->createCollectionController($collectionManager)->getCollectionsAction($paramFetcher));
@@ -35,9 +44,9 @@ class CollectionControllerTest extends TestCase
 
     public function testGetCollectionAction()
     {
-        $collection = $this->createMock('Sonata\ClassificationBundle\Model\CollectionInterface');
+        $collection = $this->createMock(CollectionInterface::class);
 
-        $collectionManager = $this->createMock('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
+        $collectionManager = $this->createMock(CollectionManagerInterface::class);
         $collectionManager->expects($this->once())->method('find')->will($this->returnValue($collection));
 
         $this->assertEquals($collection, $this->createCollectionController($collectionManager)->getCollectionAction(1));
@@ -45,7 +54,7 @@ class CollectionControllerTest extends TestCase
 
     public function testGetCollectionNotFoundExceptionAction()
     {
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Collection (42) not found');
 
         $this->createCollectionController()->getCollectionAction(42);
@@ -53,93 +62,93 @@ class CollectionControllerTest extends TestCase
 
     public function testPostCollectionAction()
     {
-        $collection = $this->createMock('Sonata\ClassificationBundle\Model\CollectionInterface');
+        $collection = $this->createMock(CollectionInterface::class);
 
-        $collectionManager = $this->createMock('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
+        $collectionManager = $this->createMock(CollectionManagerInterface::class);
         $collectionManager->expects($this->once())->method('save')->will($this->returnValue($collection));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($collection));
         $form->expects($this->once())->method('all')->will($this->returnValue([]));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCollectionController($collectionManager, $formFactory)->postCollectionAction(new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPostCollectionInvalidAction()
     {
-        $collection = $this->createMock('Sonata\ClassificationBundle\Model\CollectionInterface');
+        $collection = $this->createMock(CollectionInterface::class);
 
-        $collectionManager = $this->createMock('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
+        $collectionManager = $this->createMock(CollectionManagerInterface::class);
         $collectionManager->expects($this->never())->method('save')->will($this->returnValue($collectionManager));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->once())->method('all')->will($this->returnValue([]));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCollectionController($collectionManager, $formFactory)->postCollectionAction(new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testPutCollectionAction()
     {
-        $collection = $this->createMock('Sonata\ClassificationBundle\Model\CollectionInterface');
+        $collection = $this->createMock(CollectionInterface::class);
 
-        $collectionManager = $this->createMock('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
+        $collectionManager = $this->createMock(CollectionManagerInterface::class);
         $collectionManager->expects($this->once())->method('find')->will($this->returnValue($collection));
         $collectionManager->expects($this->once())->method('save')->will($this->returnValue($collection));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($collection));
         $form->expects($this->once())->method('all')->will($this->returnValue([]));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCollectionController($collectionManager, $formFactory)->putCollectionAction(1, new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPutPostInvalidAction()
     {
-        $collection = $this->createMock('Sonata\ClassificationBundle\Model\CollectionInterface');
+        $collection = $this->createMock(CollectionInterface::class);
 
-        $collectionManager = $this->createMock('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
+        $collectionManager = $this->createMock(CollectionManagerInterface::class);
         $collectionManager->expects($this->once())->method('find')->will($this->returnValue($collection));
         $collectionManager->expects($this->never())->method('save')->will($this->returnValue($collection));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->once())->method('all')->will($this->returnValue([]));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCollectionController($collectionManager, $formFactory)->putCollectionAction(1, new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testDeleteCollectionAction()
     {
-        $collection = $this->createMock('Sonata\ClassificationBundle\Model\CollectionInterface');
+        $collection = $this->createMock(CollectionInterface::class);
 
-        $collectionManager = $this->createMock('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
+        $collectionManager = $this->createMock(CollectionManagerInterface::class);
         $collectionManager->expects($this->once())->method('find')->will($this->returnValue($collection));
         $collectionManager->expects($this->once())->method('delete');
 
@@ -150,9 +159,9 @@ class CollectionControllerTest extends TestCase
 
     public function testDeleteCollectionInvalidAction()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException(NotFoundHttpException::class);
 
-        $collectionManager = $this->createMock('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
+        $collectionManager = $this->createMock(CollectionManagerInterface::class);
         $collectionManager->expects($this->once())->method('find')->will($this->returnValue(null));
         $collectionManager->expects($this->never())->method('delete');
 
@@ -170,10 +179,10 @@ class CollectionControllerTest extends TestCase
     protected function createCollectionController($collectionManager = null, $formFactory = null)
     {
         if (null === $collectionManager) {
-            $collectionManager = $this->createMock('Sonata\ClassificationBundle\Model\CollectionManagerInterface');
+            $collectionManager = $this->createMock(CollectionManagerInterface::class);
         }
         if (null === $formFactory) {
-            $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+            $formFactory = $this->createMock(FormFactoryInterface::class);
         }
 
         return new CollectionController($collectionManager, $formFactory);

--- a/tests/Controller/Api/ContextControllerTest.php
+++ b/tests/Controller/Api/ContextControllerTest.php
@@ -11,9 +11,18 @@
 
 namespace Sonata\ClassificationBundle\Tests\Controller\Api;
 
+use FOS\RestBundle\Request\ParamFetcherInterface;
+use FOS\RestBundle\View\View;
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Datagrid\Pager;
 use Sonata\ClassificationBundle\Controller\Api\ContextController;
+use Sonata\ClassificationBundle\Model\ContextInterface;
+use Sonata\ClassificationBundle\Model\ContextManagerInterface;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@gmail.com>
@@ -22,12 +31,12 @@ class ContextControllerTest extends TestCase
 {
     public function testGetContextsAction()
     {
-        $paramFetcher = $this->createMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->createMock(ParamFetcherInterface::class);
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue([]));
 
-        $pager = $this->getMockBuilder('Sonata\AdminBundle\Datagrid\Pager')->disableOriginalConstructor()->getMock();
+        $pager = $this->createMock(Pager::class);
 
-        $contextManager = $this->createMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $contextManager = $this->createMock(ContextManagerInterface::class);
         $contextManager->expects($this->once())->method('getPager')->will($this->returnValue($pager));
 
         $this->assertSame($pager, $this->createContextController($contextManager)->getContextsAction($paramFetcher));
@@ -35,9 +44,9 @@ class ContextControllerTest extends TestCase
 
     public function testGetContextAction()
     {
-        $context = $this->createMock('Sonata\ClassificationBundle\Model\ContextInterface');
+        $context = $this->createMock(ContextInterface::class);
 
-        $contextManager = $this->createMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $contextManager = $this->createMock(ContextManagerInterface::class);
         $contextManager->expects($this->once())->method('find')->will($this->returnValue($context));
 
         $this->assertEquals($context, $this->createContextController($contextManager)->getContextAction(1));
@@ -45,7 +54,7 @@ class ContextControllerTest extends TestCase
 
     public function testGetContextNotFoundExceptionAction()
     {
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Context (42) not found');
 
         $this->createContextController()->getContextAction(42);
@@ -53,91 +62,91 @@ class ContextControllerTest extends TestCase
 
     public function testPostContextAction()
     {
-        $context = $this->createMock('Sonata\ClassificationBundle\Model\ContextInterface');
+        $context = $this->createMock(ContextInterface::class);
 
-        $contextManager = $this->createMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $contextManager = $this->createMock(ContextManagerInterface::class);
         $contextManager->expects($this->once())->method('save')->will($this->returnValue($context));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($context));
         $form->expects($this->once())->method('all')->will($this->returnValue([]));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createContextController($contextManager, $formFactory)->postContextAction(new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPostContextInvalidAction()
     {
-        $contextManager = $this->createMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $contextManager = $this->createMock(ContextManagerInterface::class);
         $contextManager->expects($this->never())->method('save')->will($this->returnValue($contextManager));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->once())->method('all')->will($this->returnValue([]));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createContextController($contextManager, $formFactory)->postContextAction(new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testPutContextAction()
     {
-        $context = $this->createMock('Sonata\ClassificationBundle\Model\ContextInterface');
+        $context = $this->createMock(ContextInterface::class);
 
-        $contextManager = $this->createMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $contextManager = $this->createMock(ContextManagerInterface::class);
         $contextManager->expects($this->once())->method('find')->will($this->returnValue($context));
         $contextManager->expects($this->once())->method('save')->will($this->returnValue($context));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($context));
         $form->expects($this->once())->method('all')->will($this->returnValue([]));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createContextController($contextManager, $formFactory)->putContextAction(1, new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPutPostInvalidAction()
     {
-        $context = $this->createMock('Sonata\ClassificationBundle\Model\ContextInterface');
+        $context = $this->createMock(ContextInterface::class);
 
-        $contextManager = $this->createMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $contextManager = $this->createMock(ContextManagerInterface::class);
         $contextManager->expects($this->once())->method('find')->will($this->returnValue($context));
         $contextManager->expects($this->never())->method('save')->will($this->returnValue($context));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->once())->method('all')->will($this->returnValue([]));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createContextController($contextManager, $formFactory)->putContextAction(1, new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testDeleteContextAction()
     {
-        $context = $this->createMock('Sonata\ClassificationBundle\Model\ContextInterface');
+        $context = $this->createMock(ContextInterface::class);
 
-        $contextManager = $this->createMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $contextManager = $this->createMock(ContextManagerInterface::class);
         $contextManager->expects($this->once())->method('find')->will($this->returnValue($context));
         $contextManager->expects($this->once())->method('delete');
 
@@ -148,9 +157,9 @@ class ContextControllerTest extends TestCase
 
     public function testDeleteContextInvalidAction()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException(NotFoundHttpException::class);
 
-        $contextManager = $this->createMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $contextManager = $this->createMock(ContextManagerInterface::class);
         $contextManager->expects($this->once())->method('find')->will($this->returnValue(null));
         $contextManager->expects($this->never())->method('delete');
 
@@ -168,10 +177,10 @@ class ContextControllerTest extends TestCase
     protected function createContextController($contextManager = null, $formFactory = null)
     {
         if (null === $contextManager) {
-            $contextManager = $this->createMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+            $contextManager = $this->createMock(ContextManagerInterface::class);
         }
         if (null === $formFactory) {
-            $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+            $formFactory = $this->createMock(FormFactoryInterface::class);
         }
 
         return new ContextController($contextManager, $formFactory);

--- a/tests/Controller/Api/TagControllerTest.php
+++ b/tests/Controller/Api/TagControllerTest.php
@@ -11,9 +11,18 @@
 
 namespace Sonata\ClassificationBundle\Tests\Controller\Api;
 
+use FOS\RestBundle\Request\ParamFetcherInterface;
+use FOS\RestBundle\View\View;
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Datagrid\Pager;
 use Sonata\ClassificationBundle\Controller\Api\TagController;
+use Sonata\ClassificationBundle\Model\TagInterface;
+use Sonata\ClassificationBundle\Model\TagManagerInterface;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * @author Vincent Composieux <vincent.composieux@gmail.com>
@@ -22,12 +31,12 @@ class TagControllerTest extends TestCase
 {
     public function testGetTagsAction()
     {
-        $paramFetcher = $this->createMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->createMock(ParamFetcherInterface::class);
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue([]));
 
-        $pager = $this->getMockBuilder('Sonata\AdminBundle\Datagrid\Pager')->disableOriginalConstructor()->getMock();
+        $pager = $this->createMock(Pager::class);
 
-        $tagManager = $this->createMock('Sonata\ClassificationBundle\Model\TagManagerInterface');
+        $tagManager = $this->createMock(TagManagerInterface::class);
         $tagManager->expects($this->once())->method('getPager')->will($this->returnValue($pager));
 
         $this->assertSame($pager, $this->createTagController($tagManager)->getTagsAction($paramFetcher));
@@ -35,9 +44,9 @@ class TagControllerTest extends TestCase
 
     public function testGetTagAction()
     {
-        $tag = $this->createMock('Sonata\ClassificationBundle\Model\TagInterface');
+        $tag = $this->createMock(TagInterface::class);
 
-        $tagManager = $this->createMock('Sonata\ClassificationBundle\Model\TagManagerInterface');
+        $tagManager = $this->createMock(TagManagerInterface::class);
         $tagManager->expects($this->once())->method('find')->will($this->returnValue($tag));
 
         $this->assertEquals($tag, $this->createTagController($tagManager)->getTagAction(1));
@@ -45,7 +54,7 @@ class TagControllerTest extends TestCase
 
     public function testGetTagNotFoundExceptionAction()
     {
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Tag (42) not found');
 
         $this->createTagController()->getTagAction(42);
@@ -53,93 +62,93 @@ class TagControllerTest extends TestCase
 
     public function testPostTagAction()
     {
-        $tag = $this->createMock('Sonata\ClassificationBundle\Model\TagInterface');
+        $tag = $this->createMock(TagInterface::class);
 
-        $tagManager = $this->createMock('Sonata\ClassificationBundle\Model\TagManagerInterface');
+        $tagManager = $this->createMock(TagManagerInterface::class);
         $tagManager->expects($this->once())->method('save')->will($this->returnValue($tag));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($tag));
         $form->expects($this->once())->method('all')->will($this->returnValue([]));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createTagController($tagManager, $formFactory)->postTagAction(new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPostTagInvalidAction()
     {
-        $tag = $this->createMock('Sonata\ClassificationBundle\Model\TagInterface');
+        $tag = $this->createMock(TagInterface::class);
 
-        $tagManager = $this->createMock('Sonata\ClassificationBundle\Model\TagManagerInterface');
+        $tagManager = $this->createMock(TagManagerInterface::class);
         $tagManager->expects($this->never())->method('save')->will($this->returnValue($tagManager));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->once())->method('all')->will($this->returnValue([]));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createTagController($tagManager, $formFactory)->postTagAction(new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testPutTagAction()
     {
-        $tag = $this->createMock('Sonata\ClassificationBundle\Model\TagInterface');
+        $tag = $this->createMock(TagInterface::class);
 
-        $tagManager = $this->createMock('Sonata\ClassificationBundle\Model\TagManagerInterface');
+        $tagManager = $this->createMock(TagManagerInterface::class);
         $tagManager->expects($this->once())->method('find')->will($this->returnValue($tag));
         $tagManager->expects($this->once())->method('save')->will($this->returnValue($tag));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($tag));
         $form->expects($this->once())->method('all')->will($this->returnValue([]));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createTagController($tagManager, $formFactory)->putTagAction(1, new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPutPostInvalidAction()
     {
-        $tag = $this->createMock('Sonata\ClassificationBundle\Model\TagInterface');
+        $tag = $this->createMock(TagInterface::class);
 
-        $tagManager = $this->createMock('Sonata\ClassificationBundle\Model\TagManagerInterface');
+        $tagManager = $this->createMock(TagManagerInterface::class);
         $tagManager->expects($this->once())->method('find')->will($this->returnValue($tag));
         $tagManager->expects($this->never())->method('save')->will($this->returnValue($tag));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->once())->method('all')->will($this->returnValue([]));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createTagController($tagManager, $formFactory)->putTagAction(1, new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testDeleteTagAction()
     {
-        $tag = $this->createMock('Sonata\ClassificationBundle\Model\TagInterface');
+        $tag = $this->createMock(TagInterface::class);
 
-        $tagManager = $this->createMock('Sonata\ClassificationBundle\Model\TagManagerInterface');
+        $tagManager = $this->createMock(TagManagerInterface::class);
         $tagManager->expects($this->once())->method('find')->will($this->returnValue($tag));
         $tagManager->expects($this->once())->method('delete');
 
@@ -150,9 +159,9 @@ class TagControllerTest extends TestCase
 
     public function testDeleteTagInvalidAction()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException(NotFoundHttpException::class);
 
-        $tagManager = $this->createMock('Sonata\ClassificationBundle\Model\TagManagerInterface');
+        $tagManager = $this->createMock(TagManagerInterface::class);
         $tagManager->expects($this->once())->method('find')->will($this->returnValue(null));
         $tagManager->expects($this->never())->method('delete');
 
@@ -170,10 +179,10 @@ class TagControllerTest extends TestCase
     protected function createTagController($tagManager = null, $formFactory = null)
     {
         if (null === $tagManager) {
-            $tagManager = $this->createMock('Sonata\ClassificationBundle\Model\TagManagerInterface');
+            $tagManager = $this->createMock(TagManagerInterface::class);
         }
         if (null === $formFactory) {
-            $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+            $formFactory = $this->createMock(FormFactoryInterface::class);
         }
 
         return new TagController($tagManager, $formFactory);

--- a/tests/Controller/CategoryAdminControllerTest.php
+++ b/tests/Controller/CategoryAdminControllerTest.php
@@ -14,17 +14,32 @@ namespace Sonata\ClassificationBundle\Tests;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Datagrid\DatagridInterface;
+use Sonata\ClassificationBundle\Admin\CategoryAdmin;
 use Sonata\ClassificationBundle\Controller\CategoryAdminController;
+use Sonata\ClassificationBundle\Entity\CategoryManager;
+use Sonata\ClassificationBundle\Entity\ContextManager;
+use Sonata\ClassificationBundle\Model\Category;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
+use Sonata\ClassificationBundle\Model\Context;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Command\DebugCommand;
 use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 /**
  * @author Dariusz Markowicz <dmarkowicz77@gmail.com>
@@ -35,6 +50,11 @@ class CategoryAdminControllerTest extends TestCase
      * @var Request
      */
     private $request;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
 
     /**
      * @var AdminInterface
@@ -86,9 +106,11 @@ class CategoryAdminControllerTest extends TestCase
      */
     protected function setUp()
     {
-        $this->container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->container = $this->createMock(ContainerInterface::class);
 
         $this->request = new Request();
+        $this->requestStack = new RequestStack();
+        $this->requestStack->push($this->request);
         $this->pool = new Pool($this->container, 'title', 'logo.png');
         $this->pool->setAdminServiceIds(['foo.admin']);
         $this->request->attributes->set('_sonata_admin', 'foo.admin');
@@ -99,7 +121,7 @@ class CategoryAdminControllerTest extends TestCase
         $params = &$this->parameters;
         $template = &$this->template;
 
-        $templating = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine')
+        $templating = $this->getMockBuilder(DelegatingEngine::class)
             ->setMethods([])
             ->setConstructorArgs([$this->container, []])
             ->getMock();
@@ -128,42 +150,47 @@ class CategoryAdminControllerTest extends TestCase
         // php 5.3 BC
         $pool = $this->pool;
         $request = $this->request;
+        $requestStack = $this->requestStack;
 
-        $twig = $this->getMockBuilder('Twig_Environment')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $twig = $this->createMock(\Twig_Environment::class);
 
-        $twigRenderer = $this->createMock('Symfony\Bridge\Twig\Form\TwigRendererInterface');
-
-        $formExtension = new FormExtension($twigRenderer);
+        // BC for Symfony < 3.4 where runtime should be TwigRenderer
+        if (!method_exists(DebugCommand::class, 'getLoaderPaths')) {
+            $formRenderer = $this->createMock(TwigRenderer::class);
+            $formExtension = new FormExtension($formRenderer);
+        } else {
+            $formRenderer = $this->createMock(FormRenderer::class);
+            $formExtension = new FormExtension();
+        }
 
         $twig->expects($this->any())
             ->method('getExtension')
             ->will($this->returnCallback(function ($name) use ($formExtension) {
                 switch ($name) {
                     case 'form':
-                    case 'Symfony\Bridge\Twig\Extension\FormExtension':
+                    case FormExtension::class:
                         return $formExtension;
                 }
             }));
 
         $twig->expects($this->any())
             ->method('getRuntime')
-            ->will($this->returnCallback(function ($name) use ($twigRenderer) {
+            ->will($this->returnCallback(function ($name) use ($formRenderer) {
                 switch ($name) {
-                    case 'Symfony\Bridge\Twig\Form\TwigRenderer':
-                        if (method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
-                            return $twigRenderer;
+                    case TwigRenderer::class:
+                    case FormRenderer::class:
+                        if (method_exists(AppVariable::class, 'getToken')) {
+                            return $formRenderer;
                         }
 
-                        throw new \Twig_Error_Runtime('This runtime exists when Symony >= 3.2.');
+                        throw new \Twig_Error_Runtime('This runtime exists when Symfony >= 3.2.');
                 }
             }));
 
         // Prefer Symfony 2.x interfaces
-        if (interface_exists('Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface')) {
+        if (interface_exists(CsrfProviderInterface::class)) {
             $this->csrfProvider = $this->getMockBuilder(
-                'Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface'
+                CsrfProviderInterface::class
             )
                 ->getMock();
 
@@ -184,7 +211,7 @@ class CategoryAdminControllerTest extends TestCase
                 }));
         } else {
             $this->csrfProvider = $this->getMockBuilder(
-                'Symfony\Component\Security\Csrf\CsrfTokenManagerInterface'
+                CsrfTokenManagerInterface::class
             )
                 ->getMock();
 
@@ -208,19 +235,13 @@ class CategoryAdminControllerTest extends TestCase
         // php 5.3 BC
         $csrfProvider = $this->csrfProvider;
 
-        $this->admin = $this->getMockBuilder('Sonata\ClassificationBundle\Admin\CategoryAdmin')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->admin = $this->createMock(CategoryAdmin::class);
         $admin = $this->admin;
 
-        $this->categoryManager = $this->getMockBuilder('Sonata\ClassificationBundle\Entity\CategoryManager')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->categoryManager = $this->createMock(CategoryManager::class);
         $categoryManager = $this->categoryManager;
 
-        $this->contextManager = $this->getMockBuilder('Sonata\ClassificationBundle\Entity\ContextManager')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->contextManager = $this->createMock(ContextManager::class);
         $contextManager = $this->contextManager;
 
         $this->container->expects($this->any())
@@ -229,6 +250,7 @@ class CategoryAdminControllerTest extends TestCase
                 $pool,
                 $admin,
                 $request,
+                $requestStack,
                 $templating,
                 $twig,
                 $csrfProvider,
@@ -240,6 +262,8 @@ class CategoryAdminControllerTest extends TestCase
                         return $pool;
                     case 'request':
                         return $request;
+                    case 'request_stack':
+                        return $requestStack;
                     case 'foo.admin':
                         return $admin;
                     case 'templating':
@@ -292,6 +316,10 @@ class CategoryAdminControllerTest extends TestCase
                 )
             );
 
+        $this->admin->expects($this->any())
+            ->method('getTemplate')
+            ->will($this->returnValue('SonataClassificationBundle:CategoryAdmin:list.html.twig'));
+
         $this->controller = new CategoryAdminController();
         $this->controller->setContainer($this->container);
     }
@@ -307,7 +335,7 @@ class CategoryAdminControllerTest extends TestCase
 
         $result = $this->controller->listAction($this->request);
         $this->assertInstanceOf(
-            'Symfony\Component\HttpFoundation\RedirectResponse', $result);
+            RedirectResponse::class, $result);
         $this->assertSame('tree?hide_context=0', $result->getTargetUrl());
     }
 
@@ -319,9 +347,9 @@ class CategoryAdminControllerTest extends TestCase
         $this->request->query->set('_list_mode', 'list');
         $this->request->query->set('filter', 'filter[context][value]='.($context ? $context : ''));
 
-        $datagrid = $this->createMock('Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock(DatagridInterface::class);
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+        $form = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -349,7 +377,7 @@ class CategoryAdminControllerTest extends TestCase
             ->method('getPersistentParameter')
             ->will($this->returnValue($context));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response',
+        $this->assertInstanceOf(Response::class,
             $this->controller->listAction($this->request));
     }
 
@@ -366,11 +394,9 @@ class CategoryAdminControllerTest extends TestCase
      */
     public function testTreeAction($context, $categories)
     {
-        $datagrid = $this->createMock('Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $datagrid = $this->createMock(DatagridInterface::class);
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $form = $this->createMock(Form::class);
 
         $form->expects($this->once())
             ->method('createView')
@@ -403,7 +429,7 @@ class CategoryAdminControllerTest extends TestCase
 
         $categoriesMock = [];
         foreach ($categories as $category) {
-            $categoryMock = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Category');
+            $categoryMock = $this->getMockForAbstractClass(Category::class);
             $categoryMock->setName($category[0]);
             if ($category[1]) {
                 $categoryMock->setContext($this->getContextMock($category[1]));
@@ -416,7 +442,7 @@ class CategoryAdminControllerTest extends TestCase
             ->method('getRootCategoriesSplitByContexts')
             ->will($this->returnValue($categoriesMock));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response',
+        $this->assertInstanceOf(Response::class,
             $this->controller->treeAction($this->request));
     }
 
@@ -443,7 +469,7 @@ class CategoryAdminControllerTest extends TestCase
 
     private function getContextMock($id)
     {
-        $contextMock = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Context');
+        $contextMock = $this->getMockForAbstractClass(Context::class);
         $contextMock->expects($this->any())->method('getId')->will($this->returnValue($id));
         $contextMock->setName($id);
         $contextMock->setEnabled(true);

--- a/tests/Entity/CategoryManagerTest.php
+++ b/tests/Entity/CategoryManagerTest.php
@@ -11,10 +11,13 @@
 
 namespace Sonata\ClassificationBundle\Tests\Entity;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\AbstractQuery;
 use PHPUnit\Framework\TestCase;
 use Sonata\ClassificationBundle\Entity\BaseCategory;
 use Sonata\ClassificationBundle\Entity\BaseContext;
 use Sonata\ClassificationBundle\Entity\CategoryManager;
+use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
 
 abstract class CategoryTest extends BaseCategory
@@ -95,13 +98,13 @@ class CategoryManagerTest extends TestCase
     public function testGetCategoriesWithMultipleRootsInContext()
     {
         /** @var ContextTest $context */
-        $context = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\ContextTest');
+        $context = $this->getMockForAbstractClass(ContextTest::class);
         $context->setId(1);
         $context->setName('default');
         $context->setEnabled(true);
 
         /** @var CategoryTest $categoryFoo */
-        $categoryFoo = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryFoo = $this->getMockForAbstractClass(CategoryTest::class);
         $categoryFoo->setId(1);
         $categoryFoo->setName('foo');
         $categoryFoo->setContext($context);
@@ -109,7 +112,7 @@ class CategoryManagerTest extends TestCase
         $categoryFoo->setEnabled(true);
 
         /** @var CategoryTest $categoryBar */
-        $categoryBar = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryBar = $this->getMockForAbstractClass(CategoryTest::class);
         $categoryBar->setId(2);
         $categoryBar->setName('bar');
         $categoryBar->setContext($context);
@@ -127,13 +130,13 @@ class CategoryManagerTest extends TestCase
     public function testGetRootCategoryWithChildren()
     {
         /** @var ContextTest $context */
-        $context = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\ContextTest');
+        $context = $this->getMockForAbstractClass(ContextTest::class);
         $context->setId(1);
         $context->setName('default');
         $context->setEnabled(true);
 
         /** @var CategoryTest $categoryFoo */
-        $categoryFoo = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryFoo = $this->getMockForAbstractClass(CategoryTest::class);
         $categoryFoo->setId(1);
         $categoryFoo->setName('foo');
         $categoryFoo->setContext($context);
@@ -141,7 +144,7 @@ class CategoryManagerTest extends TestCase
         $categoryFoo->setEnabled(true);
 
         /** @var CategoryTest $categoryBar */
-        $categoryBar = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryBar = $this->getMockForAbstractClass(CategoryTest::class);
         $categoryBar->setId(2);
         $categoryBar->setName('bar');
         $categoryBar->setContext($context);
@@ -158,13 +161,13 @@ class CategoryManagerTest extends TestCase
     public function testGetRootCategory()
     {
         /** @var ContextTest $context */
-        $context = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\ContextTest');
+        $context = $this->getMockForAbstractClass(ContextTest::class);
         $context->setId(1);
         $context->setName('default');
         $context->setEnabled(true);
 
         /** @var CategoryTest $categoryFoo */
-        $categoryFoo = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryFoo = $this->getMockForAbstractClass(CategoryTest::class);
         $categoryFoo->setId(1);
         $categoryFoo->setName('foo');
         $categoryFoo->setContext($context);
@@ -181,13 +184,13 @@ class CategoryManagerTest extends TestCase
     public function testGetRootCategoriesForContext()
     {
         /** @var ContextTest $context */
-        $context = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\ContextTest');
+        $context = $this->getMockForAbstractClass(ContextTest::class);
         $context->setId(1);
         $context->setName('default');
         $context->setEnabled(true);
 
         /** @var CategoryTest $categoryFoo */
-        $categoryFoo = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryFoo = $this->getMockForAbstractClass(CategoryTest::class);
         $categoryFoo->setId(1);
         $categoryFoo->setName('foo');
         $categoryFoo->setContext($context);
@@ -195,7 +198,7 @@ class CategoryManagerTest extends TestCase
         $categoryFoo->setEnabled(true);
 
         /** @var CategoryTest $categoryBar */
-        $categoryBar = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryBar = $this->getMockForAbstractClass(CategoryTest::class);
         $categoryBar->setId(2);
         $categoryBar->setName('bar');
         $categoryBar->setContext($context);
@@ -213,19 +216,19 @@ class CategoryManagerTest extends TestCase
     public function testGetRootCategories()
     {
         /** @var ContextTest $contextFoo */
-        $contextFoo = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\ContextTest');
+        $contextFoo = $this->getMockForAbstractClass(ContextTest::class);
         $contextFoo->setId(1);
         $contextFoo->setName('foo');
         $contextFoo->setEnabled(true);
 
         /** @var ContextTest $contextBar */
-        $contextBar = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\ContextTest');
+        $contextBar = $this->getMockForAbstractClass(ContextTest::class);
         $contextBar->setId(2);
         $contextBar->setName('bar');
         $contextBar->setEnabled(true);
 
         /** @var CategoryTest $categoryFoo */
-        $categoryFoo = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryFoo = $this->getMockForAbstractClass(CategoryTest::class);
         $categoryFoo->setId(1);
         $categoryFoo->setName('foo');
         $categoryFoo->setContext($contextFoo);
@@ -233,7 +236,7 @@ class CategoryManagerTest extends TestCase
         $categoryFoo->setEnabled(true);
 
         /** @var CategoryTest $categoryBar */
-        $categoryBar = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryBar = $this->getMockForAbstractClass(CategoryTest::class);
         $categoryBar->setId(2);
         $categoryBar->setName('bar');
         $categoryBar->setContext($contextBar);
@@ -253,19 +256,19 @@ class CategoryManagerTest extends TestCase
     public function testGetRootCategoriesSplitByContexts()
     {
         /** @var ContextTest $contextFoo */
-        $contextFoo = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\ContextTest');
+        $contextFoo = $this->getMockForAbstractClass(ContextTest::class);
         $contextFoo->setId(1);
         $contextFoo->setName('foo');
         $contextFoo->setEnabled(true);
 
         /** @var ContextTest $contextBar */
-        $contextBar = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\ContextTest');
+        $contextBar = $this->getMockForAbstractClass(ContextTest::class);
         $contextBar->setId(2);
         $contextBar->setName('bar');
         $contextBar->setEnabled(true);
 
         /** @var CategoryTest $categoryFoo */
-        $categoryFoo = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryFoo = $this->getMockForAbstractClass(CategoryTest::class);
         $categoryFoo->setId(1);
         $categoryFoo->setName('foo');
         $categoryFoo->setContext($contextFoo);
@@ -273,7 +276,7 @@ class CategoryManagerTest extends TestCase
         $categoryFoo->setEnabled(true);
 
         /** @var CategoryTest $categoryBar */
-        $categoryBar = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Tests\Entity\CategoryTest');
+        $categoryBar = $this->getMockForAbstractClass(CategoryTest::class);
         $categoryBar->setId(2);
         $categoryBar->setName('bar');
         $categoryBar->setContext($contextBar);
@@ -295,17 +298,17 @@ class CategoryManagerTest extends TestCase
         $em = EntityManagerMockFactory::create($this, $qbCallback, []);
 
         if (null != $createQueryResult) {
-            $query = $this->getMockBuilder('Doctrine\ORM\AbstractQuery')->disableOriginalConstructor()->getMock();
+            $query = $this->createMock(AbstractQuery::class);
             $query->expects($this->once())->method('execute')->will($this->returnValue($createQueryResult));
             $query->expects($this->any())->method('setParameter')->will($this->returnValue($query));
             $em->expects($this->once())->method('createQuery')->will($this->returnValue($query));
         }
 
-        $registry = $this->getMockForAbstractClass('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->getMockForAbstractClass(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        $contextManager = $this->createMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $contextManager = $this->createMock(ContextManagerInterface::class);
 
-        return new CategoryManager('Sonata\PageBundle\Entity\BaseCategory', $registry, $contextManager);
+        return new CategoryManager(BaseCategory::class, $registry, $contextManager);
     }
 }

--- a/tests/Entity/CollectionManagerTest.php
+++ b/tests/Entity/CollectionManagerTest.php
@@ -11,7 +11,9 @@
 
 namespace Sonata\ClassificationBundle\Tests\Entity;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
+use Sonata\ClassificationBundle\Entity\BaseCollection;
 use Sonata\ClassificationBundle\Entity\CollectionManager;
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
 
@@ -61,9 +63,9 @@ class CollectionManagerTest extends TestCase
     {
         $em = EntityManagerMockFactory::create($this, $qbCallback, []);
 
-        $registry = $this->getMockForAbstractClass('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->getMockForAbstractClass(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        return new CollectionManager('Sonata\PageBundle\Entity\BaseCollection', $registry);
+        return new CollectionManager(BaseCollection::class, $registry);
     }
 }

--- a/tests/Entity/ContextManagerTest.php
+++ b/tests/Entity/ContextManagerTest.php
@@ -11,7 +11,9 @@
 
 namespace Sonata\ClassificationBundle\Tests\Entity;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
+use Sonata\ClassificationBundle\Entity\BaseContext;
 use Sonata\ClassificationBundle\Entity\ContextManager;
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
 
@@ -61,9 +63,9 @@ class ContextManagerTest extends TestCase
     {
         $em = EntityManagerMockFactory::create($this, $qbCallback, []);
 
-        $registry = $this->getMockForAbstractClass('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->getMockForAbstractClass(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        return new ContextManager('Sonata\PageBundle\Entity\BaseContext', $registry);
+        return new ContextManager(BaseContext::class, $registry);
     }
 }

--- a/tests/Entity/TagManagerTest.php
+++ b/tests/Entity/TagManagerTest.php
@@ -11,7 +11,9 @@
 
 namespace Sonata\ClassificationBundle\Tests\Entity;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
+use Sonata\ClassificationBundle\Entity\BaseTag;
 use Sonata\ClassificationBundle\Entity\TagManager;
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
 
@@ -61,9 +63,9 @@ class TagManagerTest extends TestCase
     {
         $em = EntityManagerMockFactory::create($this, $qbCallback, []);
 
-        $registry = $this->getMockForAbstractClass('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->getMockForAbstractClass(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        return new TagManager('Sonata\PageBundle\Entity\BaseTag', $registry);
+        return new TagManager(BaseTag::class, $registry);
     }
 }

--- a/tests/Form/ChoiceList/CategoryChoiceLoaderTest.php
+++ b/tests/Form/ChoiceList/CategoryChoiceLoaderTest.php
@@ -13,6 +13,7 @@ namespace Sonata\AdminBundle\Tests\Form\ChoiceList;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\ClassificationBundle\Form\ChoiceList\CategoryChoiceLoader;
+use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 
 /**
  * @author Anton Zlotnikov <exp.razor@gmail.com>
@@ -21,7 +22,7 @@ class CategoryChoiceLoaderTest extends TestCase
 {
     protected function setUp()
     {
-        if (!interface_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')) {
+        if (!interface_exists(ChoiceLoaderInterface::class)) {
             $this->markTestSkipped('Test only available for >= SF3.0');
         }
     }

--- a/tests/Form/Type/CategorySelectorTypeTest.php
+++ b/tests/Form/Type/CategorySelectorTypeTest.php
@@ -13,6 +13,8 @@ namespace Sonata\ClassificationBundle\Tests\Form\Type;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\ClassificationBundle\Form\Type\CategorySelectorType;
+use Sonata\CoreBundle\Model\ManagerInterface;
+use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -22,7 +24,7 @@ class CategorySelectorTypeTest extends TestCase
 {
     public function testConfigureOptions()
     {
-        $manager = $this->createMock('Sonata\CoreBundle\Model\ManagerInterface');
+        $manager = $this->createMock(ManagerInterface::class);
         $categorySelectorType = new CategorySelectorType($manager);
         $optionsResolver = new OptionsResolver();
         $categorySelectorType->configureOptions($optionsResolver);
@@ -33,7 +35,7 @@ class CategorySelectorTypeTest extends TestCase
         $definedOptions = $optionsResolver->getDefinedOptions();
         $this->assertContains('category', $definedOptions);
         $this->assertContains('context', $definedOptions);
-        if (interface_exists('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface')) {
+        if (interface_exists(ChoiceLoaderInterface::class)) {
             $this->assertContains('choice_loader', $definedOptions);
             $this->assertNotContains('choice_list', $definedOptions);
         } else {

--- a/tests/Model/CategoryTest.php
+++ b/tests/Model/CategoryTest.php
@@ -26,13 +26,13 @@ class CategoryTest extends TestCase
         $time = new \DateTime();
 
         /** @var ContextInterface $context */
-        $context = $this->createMock('Sonata\ClassificationBundle\Model\ContextInterface');
+        $context = $this->createMock(ContextInterface::class);
 
         /** @var MediaInterface $media */
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
 
         /** @var Category $category */
-        $category = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Category');
+        $category = $this->getMockForAbstractClass(Category::class);
         $category->setName('Hello World');
         $category->setEnabled(true);
         $category->setDescription('My description');
@@ -68,10 +68,10 @@ class CategoryTest extends TestCase
     public function testParent()
     {
         /** @var Category $parent */
-        $parent = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Category');
+        $parent = $this->getMockForAbstractClass(Category::class);
 
         /** @var Category $category */
-        $category = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Category');
+        $category = $this->getMockForAbstractClass(Category::class);
         $category->setParent($parent);
         $this->assertEquals($parent, $category->getParent());
         $this->assertCount(1, $parent->getChildren());
@@ -80,17 +80,17 @@ class CategoryTest extends TestCase
     public function testChildren()
     {
         /** @var Category $cat1 */
-        $cat1 = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Category');
+        $cat1 = $this->getMockForAbstractClass(Category::class);
         /** @var Category $cat2 */
-        $cat2 = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Category');
+        $cat2 = $this->getMockForAbstractClass(Category::class);
         /** @var Category $cat3 */
-        $cat3 = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Category');
+        $cat3 = $this->getMockForAbstractClass(Category::class);
 
         /** @var ContextInterface $context */
-        $context = $this->createMock('Sonata\ClassificationBundle\Model\ContextInterface');
+        $context = $this->createMock(ContextInterface::class);
 
         /** @var Category $category */
-        $category = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Category');
+        $category = $this->getMockForAbstractClass(Category::class);
         $category->setContext($context);
         $this->assertFalse($category->hasChildren());
 
@@ -114,19 +114,19 @@ class CategoryTest extends TestCase
     public function testPrePersist()
     {
         /** @var Category $category */
-        $category = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Category');
+        $category = $this->getMockForAbstractClass(Category::class);
         $category->prePersist();
 
-        $this->assertInstanceOf('\DateTime', $category->getCreatedAt());
-        $this->assertInstanceOf('\DateTime', $category->getUpdatedAt());
+        $this->assertInstanceOf(\DateTime::class, $category->getCreatedAt());
+        $this->assertInstanceOf(\DateTime::class, $category->getUpdatedAt());
     }
 
     public function testPreUpdate()
     {
         /** @var Category $category */
-        $category = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Category');
+        $category = $this->getMockForAbstractClass(Category::class);
         $category->preUpdate();
 
-        $this->assertInstanceOf('\DateTime', $category->getUpdatedAt());
+        $this->assertInstanceOf(\DateTime::class, $category->getUpdatedAt());
     }
 }

--- a/tests/Model/CollectionTest.php
+++ b/tests/Model/CollectionTest.php
@@ -26,13 +26,13 @@ class CollectionTest extends TestCase
         $time = new \DateTime();
 
         /** @var ContextInterface $context */
-        $context = $this->createMock('Sonata\ClassificationBundle\Model\ContextInterface');
+        $context = $this->createMock(ContextInterface::class);
 
         /** @var MediaInterface $media */
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
 
         /** @var Collection $collection */
-        $collection = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Collection');
+        $collection = $this->getMockForAbstractClass(Collection::class);
         $collection->setName('Hello World');
         $collection->setCreatedAt($time);
         $collection->setUpdatedAt($time);
@@ -66,19 +66,19 @@ class CollectionTest extends TestCase
     public function testPrePersist()
     {
         /** @var Collection $collection */
-        $collection = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Collection');
+        $collection = $this->getMockForAbstractClass(Collection::class);
         $collection->prePersist();
 
-        $this->assertInstanceOf('\DateTime', $collection->getCreatedAt());
-        $this->assertInstanceOf('\DateTime', $collection->getUpdatedAt());
+        $this->assertInstanceOf(\DateTime::class, $collection->getCreatedAt());
+        $this->assertInstanceOf(\DateTime::class, $collection->getUpdatedAt());
     }
 
     public function testPreUpdate()
     {
         /** @var Collection $collection */
-        $collection = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Collection');
+        $collection = $this->getMockForAbstractClass(Collection::class);
         $collection->preUpdate();
 
-        $this->assertInstanceOf('\DateTime', $collection->getUpdatedAt());
+        $this->assertInstanceOf(\DateTime::class, $collection->getUpdatedAt());
     }
 }

--- a/tests/Model/ContextTest.php
+++ b/tests/Model/ContextTest.php
@@ -24,7 +24,7 @@ class ContextTest extends TestCase
         $time = new \DateTime();
 
         /** @var Context $context */
-        $context = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Context');
+        $context = $this->getMockForAbstractClass(Context::class);
         // id is an int in ContextInterface and Context but used as string in implementation
         // see ContextInterface::DEFAULT_CONTEXT
         $context->setId(2);
@@ -46,9 +46,9 @@ class ContextTest extends TestCase
     public function testPreUpdate()
     {
         /** @var Context $context */
-        $context = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Context');
+        $context = $this->getMockForAbstractClass(Context::class);
         $context->preUpdate();
 
-        $this->assertInstanceOf('\DateTime', $context->getUpdatedAt());
+        $this->assertInstanceOf(\DateTime::class, $context->getUpdatedAt());
     }
 }

--- a/tests/Model/TagTest.php
+++ b/tests/Model/TagTest.php
@@ -25,10 +25,10 @@ class TagTest extends TestCase
         $time = new \DateTime();
 
         /** @var ContextInterface $context */
-        $context = $this->createMock('Sonata\ClassificationBundle\Model\ContextInterface');
+        $context = $this->createMock(ContextInterface::class);
 
         /** @var Tag $tag */
-        $tag = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Tag');
+        $tag = $this->getMockForAbstractClass(Tag::class);
         $tag->setName('Hello World');
         $tag->setCreatedAt($time);
         $tag->setUpdatedAt($time);
@@ -58,9 +58,9 @@ class TagTest extends TestCase
     public function testPreUpdate()
     {
         /** @var Tag $tag */
-        $tag = $this->getMockForAbstractClass('Sonata\ClassificationBundle\Model\Tag');
+        $tag = $this->getMockForAbstractClass(Tag::class);
         $tag->preUpdate();
 
-        $this->assertInstanceOf('\DateTime', $tag->getUpdatedAt());
+        $this->assertInstanceOf(\DateTime::class, $tag->getUpdatedAt());
     }
 }


### PR DESCRIPTION
I am targeting this branch, because it's BC.

Closes #357

## Changelog

```markdown
### Fixed
- Replaced FQCN strings with `::class` constants
- Used `createMock` in tests where it was possible
- Improved compatibility with SF 3.4, SF 4
```
