### PR TITLE
Sets the service sonata.classification.manager.category service to public

### DIFF
--- a/src/Resources/config/orm.xml
+++ b/src/Resources/config/orm.xml
@@ -7,7 +7,7 @@
         <parameter key="sonata.classification.manager.context.class">Sonata\ClassificationBundle\Entity\ContextManager</parameter>
     </parameters>
     <services>
-        <service id="sonata.classification.manager.category" class="%sonata.classification.manager.category.class%">
+        <service id="sonata.classification.manager.category" class="%sonata.classification.manager.category.class%" public="true">
             <argument>%sonata.classification.manager.category.entity%</argument>
             <argument type="service" id="doctrine"/>
             <argument type="service" id="sonata.classification.manager.context"/>


### PR DESCRIPTION
I kept getting the message 'sonata.classification.manager.category' service or alias has been removed or inlined when the container was compiled. This solves it.

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this branch should be SF4 compatible.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- Make `sonata.classification.manager.category` public

```
## Subject

In SF4 I kept getting the message: 'The "sonata.classification.manager.category" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.'

So, I listened to the message and made it public.
