### PR TITLE
Update all templates references to Twig namespaced syntax

### DIFF
--- a/docs/reference/advanced_usage.rst
+++ b/docs/reference/advanced_usage.rst
@@ -17,5 +17,5 @@ You can easily customize it with the ``SonataAdminBundle`` configuration :
                 sonata.classification.admin.category:
                     templates:
                         view:
-                            tree: 'AppBundle:CategoryAdmin:tree.html.twig'
+                            tree: '@App/CategoryAdmin/tree.html.twig'
 

--- a/docs/reference/block_bundle_integration.rst
+++ b/docs/reference/block_bundle_integration.rst
@@ -22,7 +22,7 @@ Here is a sample implementation for a custom category list block:
 
             $resolver->setDefaults(array(
                 'context'    => 'custom',
-                'template'   => 'AcmeCustomBundle:Block:block_categories.html.twig',
+                'template'   => '@AcmeCustom/Block/block_categories.html.twig',
             ));
         }
 
@@ -40,7 +40,7 @@ Here is a sample implementation for a custom category list block:
 
 .. code-block:: twig
 
-    {% extends 'SonataClassificationBundle:Block:base_block_categories.html.twig' %}
+    {% extends '@SonataClassification/Block/base_block_categories.html.twig' %}
 
     {% block link_category %}<a href="{{ path('acme_custom_category', { 'category': item.slug }) }}">{{ item.name }}</a>{% endblock %}
 

--- a/src/Block/Service/AbstractCategoriesBlockService.php
+++ b/src/Block/Service/AbstractCategoriesBlockService.php
@@ -119,7 +119,7 @@ abstract class AbstractCategoriesBlockService extends AbstractClassificationBloc
             'category' => false,
             'categoryId' => null,
             'context' => 'default',
-            'template' => 'SonataClassificationBundle:Block:base_block_categories.html.twig',
+            'template' => '@SonataClassification/Block/base_block_categories.html.twig',
         ]);
     }
 

--- a/src/Block/Service/AbstractCollectionsBlockService.php
+++ b/src/Block/Service/AbstractCollectionsBlockService.php
@@ -122,7 +122,7 @@ abstract class AbstractCollectionsBlockService extends AbstractClassificationBlo
             'collection' => false,
             'collectionId' => null,
             'context' => null,
-            'template' => 'SonataClassificationBundle:Block:base_block_collections.html.twig',
+            'template' => '@SonataClassification/Block/base_block_collections.html.twig',
         ]);
     }
 

--- a/src/Block/Service/AbstractTagsBlockService.php
+++ b/src/Block/Service/AbstractTagsBlockService.php
@@ -120,7 +120,7 @@ abstract class AbstractTagsBlockService extends AbstractClassificationBlockServi
             'tag' => false,
             'tagId' => null,
             'context' => null,
-            'template' => 'SonataClassificationBundle:Block:base_block_tags.html.twig',
+            'template' => '@SonataClassification/Block/base_block_tags.html.twig',
         ]);
     }
 

--- a/src/Resources/config/admin.xml
+++ b/src/Resources/config/admin.xml
@@ -16,8 +16,8 @@
             </call>
             <call method="setTemplates">
                 <argument type="collection">
-                    <argument key="list">SonataClassificationBundle:CategoryAdmin:list.html.twig</argument>
-                    <argument key="tree">SonataClassificationBundle:CategoryAdmin:tree.html.twig</argument>
+                    <argument key="list">@SonataClassification/CategoryAdmin/list.html.twig</argument>
+                    <argument key="tree">@SonataClassification/CategoryAdmin/tree.html.twig</argument>
                 </argument>
             </call>
         </service>

--- a/src/Resources/views/CategoryAdmin/list.html.twig
+++ b/src/Resources/views/CategoryAdmin/list.html.twig
@@ -9,10 +9,10 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_list.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_list.html.twig' %}
 
 {% block tab_menu %}
-    {% include 'SonataClassificationBundle:CategoryAdmin:list_tab_menu.html.twig' with {
+    {% include '@SonataClassification/CategoryAdmin/list_tab_menu.html.twig' with {
         'mode':   'list',
         'action': action,
         'admin':  admin,

--- a/src/Resources/views/CategoryAdmin/tree.html.twig
+++ b/src/Resources/views/CategoryAdmin/tree.html.twig
@@ -13,7 +13,7 @@ file that was distributed with this source code.
     This template is not used at all, it is just a template that you can use to create
     your own custom tree view.
 #}
-{% extends 'SonataAdminBundle:CRUD:base_list.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_list.html.twig' %}
 
 {% import _self as tree %}
 {% macro navigate_child(collection, admin, root, depth) %}
@@ -45,7 +45,7 @@ file that was distributed with this source code.
 {% endmacro %}
 
 {% block tab_menu %}
-    {% include 'SonataClassificationBundle:CategoryAdmin:list_tab_menu.html.twig' with {
+    {% include '@SonataClassification/CategoryAdmin/list_tab_menu.html.twig' with {
         'mode':   'tree',
         'action': action,
         'admin':  admin,

--- a/tests/Block/Service/AbstractCategoriesBlockServiceTest.php
+++ b/tests/Block/Service/AbstractCategoriesBlockServiceTest.php
@@ -62,7 +62,7 @@ final class AbstractCategoriesBlockServiceTest extends AbstractBlockServiceTestC
             'category' => false,
             'categoryId' => null,
             'context' => 'default',
-            'template' => 'SonataClassificationBundle:Block:base_block_categories.html.twig',
+            'template' => '@SonataClassification/Block/base_block_categories.html.twig',
         ], $blockContext);
     }
 

--- a/tests/Block/Service/AbstractCollectionsBlockServiceTest.php
+++ b/tests/Block/Service/AbstractCollectionsBlockServiceTest.php
@@ -62,7 +62,7 @@ final class AbstractCollectionsBlockServiceTest extends AbstractBlockServiceTest
             'collection' => false,
             'collectionId' => null,
             'context' => null,
-            'template' => 'SonataClassificationBundle:Block:base_block_collections.html.twig',
+            'template' => '@SonataClassification/Block/base_block_collections.html.twig',
         ], $blockContext);
     }
 

--- a/tests/Block/Service/AbstractTagsBlockServiceTest.php
+++ b/tests/Block/Service/AbstractTagsBlockServiceTest.php
@@ -62,7 +62,7 @@ final class AbstractTagsBlockServiceTest extends AbstractBlockServiceTestCase
             'tag' => false,
             'tagId' => null,
             'context' => null,
-            'template' => 'SonataClassificationBundle:Block:base_block_tags.html.twig',
+            'template' => '@SonataClassification/Block/base_block_tags.html.twig',
         ], $blockContext);
     }
 

--- a/tests/Controller/CategoryAdminControllerTest.php
+++ b/tests/Controller/CategoryAdminControllerTest.php
@@ -318,7 +318,7 @@ class CategoryAdminControllerTest extends TestCase
 
         $this->admin->expects($this->any())
             ->method('getTemplate')
-            ->will($this->returnValue('SonataClassificationBundle:CategoryAdmin:list.html.twig'));
+            ->will($this->returnValue('@SonataClassification/CategoryAdmin/list.html.twig'));
 
         $this->controller = new CategoryAdminController();
         $this->controller->setContainer($this->container);


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Switch all templates references to Twig namespaced syntax
```

## Subject

This PR is a part of a big plan of decoupling sonata-project bundles from Templating Component. See sonata-project/dev-kit#380 for details