### PR TITLE
Added more options to blocks

### DIFF
--- a/src/Block/Service/AbstractCategoriesBlockService.php
+++ b/src/Block/Service/AbstractCategoriesBlockService.php
@@ -94,7 +94,19 @@ abstract class AbstractCategoriesBlockService extends AbstractClassificationBloc
         $formMapper->add(ImmutableArrayType::class, [
                 'keys' => [
                     ['title', TextType::class, [
+                        'required' => false,
                         'label' => 'form.label_title',
+                    ]],
+                    ['translation_domain', TextType::class, [
+                        'label' => 'form.label_translation_domain',
+                        'required' => false,
+                    ]],
+                    ['icon', TextType::class, [
+                        'label' => 'form.label_icon',
+                        'required' => false,
+                    ]],
+                    ['class', TextType::class, [
+                        'label' => 'form.label_class',
                         'required' => false,
                     ]],
                     ['context', ChoiceType::class, [
@@ -115,7 +127,10 @@ abstract class AbstractCategoriesBlockService extends AbstractClassificationBloc
     public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'title' => 'Categories',
+            'title' => null,
+            'translation_domain' => null,
+            'icon' => 'fa fa-folder-open-o',
+            'class' => null,
             'category' => false,
             'categoryId' => null,
             'context' => 'default',

--- a/src/Block/Service/AbstractCollectionsBlockService.php
+++ b/src/Block/Service/AbstractCollectionsBlockService.php
@@ -97,7 +97,19 @@ abstract class AbstractCollectionsBlockService extends AbstractClassificationBlo
             ImmutableArrayType::class, [
                 'keys' => [
                     ['title', TextType::class, [
+                        'required' => false,
                         'label' => 'form.label_title',
+                    ]],
+                    ['translation_domain', TextType::class, [
+                        'label' => 'form.label_translation_domain',
+                        'required' => false,
+                    ]],
+                    ['icon', TextType::class, [
+                        'label' => 'form.label_icon',
+                        'required' => false,
+                    ]],
+                    ['class', TextType::class, [
+                        'label' => 'form.label_class',
                         'required' => false,
                     ]],
                     ['context', ChoiceType::class, [
@@ -118,7 +130,10 @@ abstract class AbstractCollectionsBlockService extends AbstractClassificationBlo
     public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'title' => 'Collections',
+            'title' => null,
+            'translation_domain' => null,
+            'icon' => 'fa fa-inpanel',
+            'class' => null,
             'collection' => false,
             'collectionId' => null,
             'context' => null,

--- a/src/Block/Service/AbstractTagsBlockService.php
+++ b/src/Block/Service/AbstractTagsBlockService.php
@@ -95,7 +95,19 @@ abstract class AbstractTagsBlockService extends AbstractClassificationBlockServi
         $formMapper->add('settings', ImmutableArrayType::class, [
                 'keys' => [
                     ['title', TextType::class, [
+                        'required' => false,
                         'label' => 'form.label_title',
+                    ]],
+                    ['translation_domain', TextType::class, [
+                        'label' => 'form.label_translation_domain',
+                        'required' => false,
+                    ]],
+                    ['icon', TextType::class, [
+                        'label' => 'form.label_icon',
+                        'required' => false,
+                    ]],
+                    ['class', TextType::class, [
+                        'label' => 'form.label_class',
                         'required' => false,
                     ]],
                     ['context', ChoiceType::class, [
@@ -116,7 +128,10 @@ abstract class AbstractTagsBlockService extends AbstractClassificationBlockServi
     public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'title' => 'Tags',
+            'title' => null,
+            'translation_domain' => null,
+            'icon' => 'fa fa-tags',
+            'class' => null,
             'tag' => false,
             'tagId' => null,
             'context' => null,

--- a/src/Resources/translations/SonataClassificationBundle.de.xliff
+++ b/src/Resources/translations/SonataClassificationBundle.de.xliff
@@ -198,6 +198,18 @@
                 <source>no_tags_found</source>
                 <target>Es konnten keine Schlüsselworte gefunden werden.</target>
             </trans-unit>
+            <trans-unit id="form.label_translation_domain">
+                <source>form.label_translation_domain</source>
+                <target>Übersetzungsdatei</target>
+            </trans-unit>
+            <trans-unit id="form.label_icon">
+                <source>form.label_icon</source>
+                <target>Icon</target>
+            </trans-unit>
+            <trans-unit id="form.label_class">
+                <source>form.label_class</source>
+                <target>CSS Klasse</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataClassificationBundle.en.xliff
+++ b/src/Resources/translations/SonataClassificationBundle.en.xliff
@@ -222,6 +222,18 @@
                 <source>Options</source>
                 <target>Options</target>
             </trans-unit>
+            <trans-unit id="form.label_translation_domain">
+                <source>form.label_translation_domain</source>
+                <target>Translation domain</target>
+            </trans-unit>
+            <trans-unit id="form.label_icon">
+                <source>form.label_icon</source>
+                <target>Icon</target>
+            </trans-unit>
+            <trans-unit id="form.label_class">
+                <source>form.label_class</source>
+                <target>CSS Class</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataClassificationBundle.fr.xliff
+++ b/src/Resources/translations/SonataClassificationBundle.fr.xliff
@@ -214,6 +214,18 @@
                 <source>breadcrumb.link_context_create</source>
                 <target>Ajouter</target>
             </trans-unit>
+            <trans-unit id="form.label_translation_domain">
+                <source>form.label_translation_domain</source>
+                <target>Domaine de traduction</target>
+            </trans-unit>
+            <trans-unit id="form.label_icon">
+                <source>form.label_icon</source>
+                <target>Icône</target>
+            </trans-unit>
+            <trans-unit id="form.label_class">
+                <source>form.label_class</source>
+                <target>Classe CSS</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/views/Block/base_block_categories.html.twig
+++ b/src/Resources/views/Block/base_block_categories.html.twig
@@ -12,10 +12,19 @@ file that was distributed with this source code.
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-    <div class="panel panel-default panel-category-list">
+    <div class="panel panel-default {{ settings.class }}">
         {% if settings.title is not empty %}
             <div class="panel-heading">
-                <h4 class="panel-title"><i class="fa fa-folder-open-o"></i> {{ settings.title }}</h4>
+                <h4 class="panel-title">
+                    {% if settings.icon %}
+                        <i class="{{ settings.icon }}" aria-hidden="true"></i>
+                    {% endif %}
+                    {% if settings.translation_domain %}
+                        {{ settings.title|trans({}, settings.translation_domain) }}
+                    {% else %}
+                        {{ settings.title }}
+                    {% endif %}
+                </h4>
             </div>
         {% endif %}
 

--- a/src/Resources/views/Block/base_block_collections.html.twig
+++ b/src/Resources/views/Block/base_block_collections.html.twig
@@ -12,10 +12,19 @@ file that was distributed with this source code.
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-    <div class="panel panel-default panel-collection-list">
+    <div class="panel panel-default {{ settings.class }}">
         {% if settings.title is not empty %}
             <div class="panel-heading">
-                <h4 class="panel-title"><i class="fa fa-inpanel"></i> {{ settings.title }}</h4>
+                <h4 class="panel-title">
+                    {% if settings.icon %}
+                        <i class="{{ settings.icon }}" aria-hidden="true"></i>
+                    {% endif %}
+                    {% if settings.translation_domain %}
+                        {{ settings.title|trans({}, settings.translation_domain) }}
+                    {% else %}
+                        {{ settings.title }}
+                    {% endif %}
+                </h4>
             </div>
         {% endif %}
 

--- a/src/Resources/views/Block/base_block_tags.html.twig
+++ b/src/Resources/views/Block/base_block_tags.html.twig
@@ -12,10 +12,19 @@ file that was distributed with this source code.
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-    <div class="panel panel-default panel-tag-list">
+    <div class="panel panel-default {{ settings.class }}">
         {% if settings.title is not empty %}
             <div class="panel-heading">
-                <h4 class="panel-title"><i class="fa fa-tags"></i> {{ settings.title }}</h4>
+                <h4 class="panel-title">
+                    {% if settings.icon %}
+                        <i class="{{ settings.icon }}" aria-hidden="true"></i>
+                    {% endif %}
+                    {% if settings.translation_domain %}
+                        {{ settings.title|trans({}, settings.translation_domain) }}
+                    {% else %}
+                        {{ settings.title }}
+                    {% endif %}
+                </h4>
             </div>
         {% endif %}
 

--- a/tests/Block/Service/AbstractCategoriesBlockServiceTest.php
+++ b/tests/Block/Service/AbstractCategoriesBlockServiceTest.php
@@ -58,7 +58,10 @@ final class AbstractCategoriesBlockServiceTest extends AbstractBlockServiceTestC
         $blockContext = $this->getBlockContext($blockService);
 
         $this->assertSettings([
-            'title' => 'Categories',
+            'title' => null,
+            'translation_domain' => null,
+            'icon' => 'fa fa-folder-open-o',
+            'class' => null,
             'category' => false,
             'categoryId' => null,
             'context' => 'default',

--- a/tests/Block/Service/AbstractCollectionsBlockServiceTest.php
+++ b/tests/Block/Service/AbstractCollectionsBlockServiceTest.php
@@ -58,7 +58,10 @@ final class AbstractCollectionsBlockServiceTest extends AbstractBlockServiceTest
         $blockContext = $this->getBlockContext($blockService);
 
         $this->assertSettings([
-            'title' => 'Collections',
+            'title' => null,
+            'translation_domain' => null,
+            'icon' => 'fa fa-inpanel',
+            'class' => null,
             'collection' => false,
             'collectionId' => null,
             'context' => null,

--- a/tests/Block/Service/AbstractTagsBlockServiceTest.php
+++ b/tests/Block/Service/AbstractTagsBlockServiceTest.php
@@ -58,7 +58,10 @@ final class AbstractTagsBlockServiceTest extends AbstractBlockServiceTestCase
         $blockContext = $this->getBlockContext($blockService);
 
         $this->assertSettings([
-            'title' => 'Tags',
+            'title' => null,
+            'translation_domain' => null,
+            'icon' => 'fa fa-tags',
+            'class' => null,
             'tag' => false,
             'tagId' => null,
             'context' => null,


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this feature is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
 - make block icon configurable
 - added block title translation domain

### Removed
 - Removed default title on blocks
```

