### PR TITLE
Update installation documentation for Symfony Flex

### DIFF
--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -5,101 +5,61 @@
 Installation
 ============
 
-* Add ``SonataClassificationBundle`` via composer:
+Prerequisites
+-------------
+
+PHP 5.6 or 7.0 and Symfony 2.8, >=3.3 or 4 are needed to make this bundle work, there are
+also some Sonata dependencies that need to be installed and configured beforehand:
+
+* `SonataEasyExtendsBundle <https://sonata-project.org/bundles/easy-extends>`_
+
+Add ``SonataClassificationBundle`` via composer:
 
 .. code-block:: bash
 
    $ composer require sonata-project/classification-bundle
 
-* Add ``SonataEasyExtendsBundle`` to the dev environment via composer:
-
-.. code-block:: bash
-
-   $ composer require --dev sonata-project/easy-extends-bundle
-
-* Add ``SonataClassificationBundle`` and  ``SonataEasyExtendsBundle`` to your application kernel:
+Now, add the new ``SonataClassificationBundle`` to ``bundles.php`` file:
 
 .. code-block:: php
+
+    <?php
+
+    // config/bundles.php
+
+    return [
+        //...
+        Sonata\ClassificationBundle\SonataClassificationBundle::class => ['all' => true],
+    ];
+
+.. note::
+    If you are not using Symfony Flex, you should enable bundles in your
+    ``AppKernel.php``.
+
+.. code-block:: php
+
+    <?php
 
     // app/AppKernel.php
 
     public function registerBundles()
     {
-        $bundles = [
-            // ...
+        return [
             new Sonata\ClassificationBundle\SonataClassificationBundle(),
             // ...
         ];
-        
-        if (in_array($this->getEnvironment(), ['dev', 'test'], true)) {
-            // ...
-            $bundles[] = new Sonata\EasyExtendsBundle\SonataEasyExtendsBundle();
-            // ...
-        }
-        
-        return $bundles;
     }
 
-* Create a configuration file named ``sonata_classification.yml``:
+Configuration
+-------------
+
+Doctrine Configuration
+~~~~~~~~~~~~~~~~~~~~~~
+Add these bundles in the config mapping definition (or enable `auto_mapping`_):
 
 .. code-block:: yaml
 
-    # sonata_classification.yml
-
-    sonata_classification:
-        # ...
-
-    doctrine:
-        orm:
-            entity_managers:
-                default:
-                    mappings:
-                        SonataClassificationBundle: ~
-                        #ApplicationSonataClassificationBundle: ~
-
-* Import the ``sonata_classification.yml`` file in your main app/config/config.yml:
-
-.. code-block:: yaml
-
-    imports:
-        #...
-        - { resource: sonata_classification.yml }
-
-* Run the easy-extends command:
-
-.. code-block:: bash
-
-    php app/console sonata:easy-extends:generate --dest=src SonataClassificationBundle
-
-* If necessary add the new namespace to the autoload:
-
-.. code-block:: php
-
-    // app/autoload.php
-
-    $loader->add("Application", __DIR__.'/src/Application');
-
-* Enable the new bundle:
-
-.. code-block:: php
-
-    // app/AppKernel.php
-
-    public function registerBundles()
-    {
-        return array(
-            // ...
-            new Application\Sonata\ClassificationBundle\ApplicationSonataClassificationBundle(),
-            // ...
-        );
-    }
-
-.. code-block:: yaml
-
-    # sonata_classification.yml
-
-    sonata_classification:
-        # ...
+    # config/packages/doctrine.yaml
 
     doctrine:
         orm:
@@ -107,4 +67,95 @@ Installation
                 default:
                     mappings:
                         ApplicationSonataClassificationBundle: ~
-                        # ...
+                        SonataClassificationBundle: ~
+
+.. note::
+    If you are not using Symfony Flex, this configuration should be added
+    to ``app/config/config.yml``.
+
+Extending the Bundle
+--------------------
+At this point, the bundle is functional, but not quite ready yet. You need to
+generate the correct entities for the media:
+
+.. code-block:: bash
+
+    bin/console sonata:easy-extends:generate SonataClassificationBundle --dest=src --namespace_prefix=App
+
+.. note::
+    If you are not using Symfony Flex, use command without ``--namespace_prefix=App``.
+
+With provided parameters, the files are generated in ``src/Application/Sonata/ClassificationBundle``.
+
+.. note::
+
+    The command will generate domain objects in ``App\Application`` namespace.
+    So you can point entities' associations to a global and common namespace.
+    This will make Entities sharing easier as your models will allow to
+    point to a global namespace. For instance the tag will be
+    ``App\Application\Sonata\ClassificationBundle\Entity\Tag``.
+
+.. note::
+    If you are not using Symfony Flex, the namespace will be ``Application\Sonata\ClassificationBundle\Entity``.
+
+Now, add the new ``Application`` Bundle into the ``bundles.php``:
+
+.. code-block:: php
+
+    <?php
+
+    // config/bundles.php
+
+    return [
+        //...
+        App\Application\Sonata\ClassificationBundle\ApplicationSonataClassificationBundle::class => ['all' => true],
+    ];
+
+.. note::
+    If you are not using Symfony Flex, add the new ``Application`` Bundle into your
+    ``AppKernel.php``.
+
+.. code-block:: php
+
+    <?php
+
+    // app/AppKernel.php
+
+    class AppKernel {
+
+        public function registerBundles()
+        {
+            return [
+                // Application Bundles
+                // ...
+                new Application\Sonata\ClassificationBundle\ApplicationSonataClassificationBundle(),
+                // ...
+            ];
+        }
+    }
+
+And configure ``ClassificationBundle`` to use the newly generated classes:
+
+.. code-block:: php
+
+    # config/packages/sonata.yaml
+
+    sonata_classification:
+        class:
+            tag: App\Application\Sonata\ClassificationBundle\Entity\Tag
+            category: App\Application\Sonata\ClassificationBundle\Entity\Category
+            collection: App\Application\Sonata\ClassificationBundle\Entity\Collection
+            context: App\Application\Sonata\ClassificationBundle\Entity\Context
+
+
+.. note::
+    If you are not using Symfony Flex, add classes without the ``App\``
+    part and this configuration should be added to ``app/config/config.yml``
+
+The only thing left is to update your schema:
+
+.. code-block:: bash
+
+    bin/console doctrine:schema:update --force
+
+.. _`auto_mapping`: http://symfony.com/doc/2.0/reference/configuration/doctrine.html#configuration-overview


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targeting this branch, because I am updating documentation for Symfony Flex.

## Subject

Updating documentation to adopt new flex structure.