### PR TITLE
Remove compatibility with FOSRest < 2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,12 +38,13 @@
         "twig/twig": "^1.14.2 || ^2.0"
     },
     "conflict": {
+        "friendsofsymfony/rest-bundle": "<2.1 || >=3.0",
         "jms/serializer": "<0.13",
         "sonata-project/block-bundle": "<3.0 || >=4.0",
         "sonata-project/media-bundle": "<3.0 || >=4.0"
     },
     "require-dev": {
-        "friendsofsymfony/rest-bundle": "^1.1 || ^2.0",
+        "friendsofsymfony/rest-bundle": "^2.1",
         "jms/serializer-bundle": "^0.13 || ^1.0",
         "sonata-project/block-bundle": "^3.3.1",
         "sonata-project/media-bundle": "^3.0",

--- a/src/Controller/Api/CategoryController.php
+++ b/src/Controller/Api/CategoryController.php
@@ -16,7 +16,6 @@ use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\View\View as FOSRestView;
-use JMS\Serializer\SerializationContext;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
@@ -254,18 +253,11 @@ class CategoryController
             $category = $form->getData();
             $this->categoryManager->save($category);
 
-            $view = FOSRestView::create($category);
+            $context = new Context();
+            $context->setGroups(['sonata_api_read']);
 
-            if (class_exists(Context::class)) {
-                $context = new Context();
-                $context->setGroups(['sonata_api_read']);
-                $view->setContext($context);
-            } else {
-                $serializationContext = SerializationContext::create();
-                $serializationContext->setGroups(['sonata_api_read']);
-                $serializationContext->enableMaxDepthChecks();
-                $view->setSerializationContext($serializationContext);
-            }
+            $view = FOSRestView::create($category);
+            $view->setContext($context);
 
             return $view;
         }

--- a/src/Controller/Api/CollectionController.php
+++ b/src/Controller/Api/CollectionController.php
@@ -16,7 +16,6 @@ use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\View\View as FOSRestView;
-use JMS\Serializer\SerializationContext;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sonata\ClassificationBundle\Model\CollectionInterface;
 use Sonata\ClassificationBundle\Model\CollectionManagerInterface;
@@ -253,18 +252,11 @@ class CollectionController
             $collection = $form->getData();
             $this->collectionManager->save($collection);
 
-            $view = FOSRestView::create($collection);
+            $context = new Context();
+            $context->setGroups(['sonata_api_read']);
 
-            if (class_exists(Context::class)) {
-                $context = new Context();
-                $context->setGroups(['sonata_api_read']);
-                $view->setContext($context);
-            } else {
-                $serializationContext = SerializationContext::create();
-                $serializationContext->setGroups(['sonata_api_read']);
-                $serializationContext->enableMaxDepthChecks();
-                $view->setSerializationContext($serializationContext);
-            }
+            $view = FOSRestView::create($collection);
+            $view->setContext($context);
 
             return $view;
         }

--- a/src/Controller/Api/ContextController.php
+++ b/src/Controller/Api/ContextController.php
@@ -16,7 +16,6 @@ use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\View\View as FOSRestView;
-use JMS\Serializer\SerializationContext;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sonata\ClassificationBundle\Model\ContextInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
@@ -253,18 +252,11 @@ class ContextController
             $context = $form->getData();
             $this->contextManager->save($context);
 
-            $view = FOSRestView::create($context);
+            $context = new Context();
+            $context->setGroups(['sonata_api_read']);
 
-            if (class_exists(Context::class)) {
-                $context = new Context();
-                $context->setGroups(['sonata_api_read']);
-                $view->setContext($context);
-            } else {
-                $serializationContext = SerializationContext::create();
-                $serializationContext->setGroups(['sonata_api_read']);
-                $serializationContext->enableMaxDepthChecks();
-                $view->setSerializationContext($serializationContext);
-            }
+            $view = FOSRestView::create($context);
+            $view->setContext($context);
 
             return $view;
         }

--- a/src/Controller/Api/TagController.php
+++ b/src/Controller/Api/TagController.php
@@ -16,7 +16,6 @@ use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\View\View as FOSRestView;
-use JMS\Serializer\SerializationContext;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sonata\ClassificationBundle\Model\TagInterface;
 use Sonata\ClassificationBundle\Model\TagManagerInterface;
@@ -253,18 +252,11 @@ class TagController
             $tag = $form->getData();
             $this->tagManager->save($tag);
 
-            $view = FOSRestView::create($tag);
+            $context = new Context();
+            $context->setGroups(['sonata_api_read']);
 
-            if (class_exists(Context::class)) {
-                $context = new Context();
-                $context->setGroups(['sonata_api_read']);
-                $view->setContext($context);
-            } else {
-                $serializationContext = SerializationContext::create();
-                $serializationContext->setGroups(['sonata_api_read']);
-                $serializationContext->enableMaxDepthChecks();
-                $view->setSerializationContext($serializationContext);
-            }
+            $view = FOSRestView::create($tag);
+            $view->setContext($context);
 
             return $view;
         }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed compatibility with older versions of FOSRestBundle (<2.1)
```

## Subject

<!-- Describe your Pull Request content here -->
Since dropping a dependency is not a BC break, this is a good start, because we are doing a lot of code just to keep compat with FOSRest 1.