### PR TITLE
Minor composer improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "cocur/slugify": "^1.4 || ^2.0 || ^3.0",
-        "sonata-project/admin-bundle": "^3.1",
-        "sonata-project/core-bundle": "^3.2",
-        "sonata-project/datagrid-bundle": "^2.2.1",
-        "sonata-project/doctrine-orm-admin-bundle": "^3.0",
-        "sonata-project/easy-extends-bundle": "^2.2",
+        "cocur/slugify": "^2.0 || ^3.0",
+        "sonata-project/admin-bundle": "^3.31",
+        "sonata-project/core-bundle": "^3.9",
+        "sonata-project/datagrid-bundle": "^2.3",
+        "sonata-project/doctrine-orm-admin-bundle": "^3.4",
+        "sonata-project/easy-extends-bundle": "^2.5",
         "symfony/config": "^2.8 || ^3.2 || ^4.0",
         "symfony/console": "^2.8 || ^3.2 || ^4.0",
         "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
@@ -35,7 +35,7 @@
         "symfony/http-foundation": "^2.8 || ^3.2 || ^4.0",
         "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0",
         "symfony/options-resolver": "^2.8 || ^3.2 || ^4.0",
-        "twig/twig": "^1.14.2 || ^2.0"
+        "twig/twig": "^1.35 || ^2.0"
     },
     "conflict": {
         "friendsofsymfony/rest-bundle": "<2.1 || >=3.0",
@@ -45,10 +45,10 @@
     },
     "require-dev": {
         "friendsofsymfony/rest-bundle": "^2.1",
-        "jms/serializer-bundle": "^0.13 || ^1.0",
-        "sonata-project/block-bundle": "^3.3.1",
-        "sonata-project/media-bundle": "^3.0",
-        "symfony/phpunit-bridge": "^3.3 || ^4.0"
+        "jms/serializer-bundle": "^1.0 || ^2.0",
+        "sonata-project/block-bundle": "^3.11",
+        "sonata-project/media-bundle": "^3.10",
+        "symfony/phpunit-bridge": "^4.0"
     },
     "suggest": {
         "sonata-project/block-bundle": "For rendering dynamic list blocks on a page.",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Compatibility with Cocur slugify `^1.0`
```

## Subject

<!-- Describe your Pull Request content here -->
- Up sonata dependencies
- Remove Cocur slugify ^1.0
- Add compatibility with jms serializer bundle 2.0 (and remove 0.x)
- Up PHPUnit-bridge to 4.0

This makes us able to add SF 4.0 on travis