### PR TITLE
Stop using Sonata\AdminBundle\Controller\CRUDController::render and use renderWithExtraParams

### DIFF
--- a/src/Controller/CategoryAdminController.php
+++ b/src/Controller/CategoryAdminController.php
@@ -59,7 +59,7 @@ class CategoryAdminController extends Controller
         // set the theme for the current Admin Form
         $this->setFormTheme($formView, $this->admin->getFilterTheme());
 
-        return $this->render($this->admin->getTemplate('list'), [
+        return $this->renderWithExtraParams($this->admin->getTemplate('list'), [
             'action' => 'list',
             'form' => $formView,
             'datagrid' => $datagrid,
@@ -115,7 +115,7 @@ class CategoryAdminController extends Controller
 
         $this->setFormTheme($formView, $this->admin->getFilterTheme());
 
-        return $this->render($this->admin->getTemplate('tree'), [
+        return $this->renderWithExtraParams($this->admin->getTemplate('tree'), [
             'action' => 'tree',
             'current_categories' => $currentCategories,
             'root_categories' => $rootCategoriesSplitByContexts,


### PR DESCRIPTION
I am targeting this branch, because is Deprecation and BC.

## Changelog

```markdown
### Changed
- Make `Sonata\ClassificationBundle\Controller\CategoryAdminController` use `renderWithExtraParams`
```

## Subject
Stop using Sonata\AdminBundle\Controller\CRUDController::render and use renderWithExtraParams