### PR TITLE
Force use translation strings for classification entities

### DIFF
--- a/src/Admin/CategoryAdmin.php
+++ b/src/Admin/CategoryAdmin.php
@@ -25,6 +25,8 @@ use Symfony\Component\Validator\Constraints\Valid;
 
 class CategoryAdmin extends ContextAwareAdmin
 {
+    protected $classnameLabel = 'Category';
+
     // NEXT_MAJOR: remove this override
     protected $formOptions = [
         'cascade_validation' => true,

--- a/src/Admin/CollectionAdmin.php
+++ b/src/Admin/CollectionAdmin.php
@@ -22,6 +22,8 @@ use Symfony\Component\Validator\Constraints\Valid;
 
 class CollectionAdmin extends ContextAwareAdmin
 {
+    protected $classnameLabel = 'Collection';
+
     // NEXT_MAJOR: remove this override
     protected $formOptions = [
         'cascade_validation' => true,

--- a/src/Admin/ContextAdmin.php
+++ b/src/Admin/ContextAdmin.php
@@ -19,6 +19,8 @@ use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 
 class ContextAdmin extends AbstractAdmin
 {
+    protected $classnameLabel = 'Context';
+
     /**
      * {@inheritdoc}
      */

--- a/src/Admin/TagAdmin.php
+++ b/src/Admin/TagAdmin.php
@@ -18,6 +18,8 @@ use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 
 class TagAdmin extends ContextAwareAdmin
 {
+    protected $classnameLabel = 'Tag';
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Force use translation strings for classification entities
```

## Subject

If a last part of Category/Collection/Context/Tag class name differs from `Category`, `Collection`, `Context` or `Tag`, then Admin will try to use non-existing translation strings for breadcrumbs instead of `breadcrumb.link_category_list` or `breadcrumb.link_tag_create`, i.e. it will use `breadcrumb.link_sonata_classification_category_list` for SonataClassificationCategory and `breadcrumb.link_sonata_classification_tag_create` for SonataClassificationTag classes.

With this PR Admin will be forced to use existing translation strings.