### PR TITLE
Disallow null value on foreign keys for associations with Context

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -26,3 +26,7 @@ If you have implemented a custom model, you must adapt the signature of the foll
  * `getRootCategoriesForContext`
  * `getAllRootCategories`
  * `getRootCategoriesSplitByContexts`
+
+## Doctrine schema update
+Disallowed null value on foreign keys for associations with Context for
+Category, Tag and Collection entities.

--- a/src/DependencyInjection/SonataClassificationExtension.php
+++ b/src/DependencyInjection/SonataClassificationExtension.php
@@ -162,6 +162,7 @@ class SonataClassificationExtension extends Extension
                 [
                     'name' => 'context',
                     'referencedColumnName' => 'id',
+                    'nullable' => false,
                 ],
             ],
             'orphanRemoval' => false,
@@ -179,6 +180,7 @@ class SonataClassificationExtension extends Extension
                 [
                     'name' => 'context',
                     'referencedColumnName' => 'id',
+                    'nullable' => false,
                 ],
             ],
             'orphanRemoval' => false,
@@ -198,6 +200,7 @@ class SonataClassificationExtension extends Extension
                 [
                     'name' => 'context',
                     'referencedColumnName' => 'id',
+                    'nullable' => false,
                 ],
             ],
             'orphanRemoval' => false,


### PR DESCRIPTION
I am targeting this branch, because existing application could be broken after applying proposed changes.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Disallow null value on foreign keys for associations with Context
```

## Subject

With this PR it won't be possible to create a `Category`, `Tag` and `Collection` with null `$context`. It was possible when ClassificationBundle is used without MediaBundle. After such Category created, there is a error Context cannot be null on a tree view. I created a recipe for ClassificationBundle, see https://github.com/symfony/recipes-contrib/pull/389, where i also added a constraint NotNull to `$context` property.