### PR TITLE
fix build by using createMock() and ContextInterface, rather than Context

### DIFF
--- a/tests/Controller/CategoryAdminControllerTest.php
+++ b/tests/Controller/CategoryAdminControllerTest.php
@@ -22,7 +22,7 @@ use Sonata\ClassificationBundle\Entity\CategoryManager;
 use Sonata\ClassificationBundle\Entity\ContextManager;
 use Sonata\ClassificationBundle\Model\Category;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
-use Sonata\ClassificationBundle\Model\Context;
+use Sonata\ClassificationBundle\Model\ContextInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 use Symfony\Bridge\Twig\AppVariable;
 use Symfony\Bridge\Twig\Command\DebugCommand;
@@ -476,7 +476,7 @@ class CategoryAdminControllerTest extends TestCase
 
     private function getContextMock($id)
     {
-        $contextMock = $this->getMockForAbstractClass(Context::class);
+        $contextMock = $this->createMock(ContextInterface::class);
         $contextMock->expects($this->any())->method('getId')->will($this->returnValue($id));
         $contextMock->setName($id);
         $contextMock->setEnabled(true);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

fix build by using createMock() and ContextInterface, rather than Context
