### PR TITLE
Fixed deprecation warnings from SonataCore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "sonata-project/admin-bundle": "^3.31",
         "sonata-project/core-bundle": "^3.9",
         "sonata-project/datagrid-bundle": "^2.3",
+        "sonata-project/doctrine-extensions": "^1.1",
         "sonata-project/doctrine-orm-admin-bundle": "^3.4",
         "sonata-project/easy-extends-bundle": "^2.5",
         "symfony/config": "^2.8 || ^3.2 || ^4.0",

--- a/src/Entity/CategoryManager.php
+++ b/src/Entity/CategoryManager.php
@@ -17,7 +17,7 @@ use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
-use Sonata\CoreBundle\Model\BaseEntityManager;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
 use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
 

--- a/src/Entity/CategoryManager.php
+++ b/src/Entity/CategoryManager.php
@@ -17,9 +17,9 @@ use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
-use Sonata\Doctrine\Entity\BaseEntityManager;
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
 use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 
 class CategoryManager extends BaseEntityManager implements CategoryManagerInterface
 {

--- a/src/Entity/CollectionManager.php
+++ b/src/Entity/CollectionManager.php
@@ -12,7 +12,7 @@
 namespace Sonata\ClassificationBundle\Entity;
 
 use Sonata\ClassificationBundle\Model\CollectionManagerInterface;
-use Sonata\CoreBundle\Model\BaseEntityManager;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
 use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
 

--- a/src/Entity/CollectionManager.php
+++ b/src/Entity/CollectionManager.php
@@ -12,9 +12,9 @@
 namespace Sonata\ClassificationBundle\Entity;
 
 use Sonata\ClassificationBundle\Model\CollectionManagerInterface;
-use Sonata\Doctrine\Entity\BaseEntityManager;
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
 use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 
 class CollectionManager extends BaseEntityManager implements CollectionManagerInterface
 {

--- a/src/Entity/ContextManager.php
+++ b/src/Entity/ContextManager.php
@@ -12,7 +12,7 @@
 namespace Sonata\ClassificationBundle\Entity;
 
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
-use Sonata\CoreBundle\Model\BaseEntityManager;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
 use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
 

--- a/src/Entity/ContextManager.php
+++ b/src/Entity/ContextManager.php
@@ -12,9 +12,9 @@
 namespace Sonata\ClassificationBundle\Entity;
 
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
-use Sonata\Doctrine\Entity\BaseEntityManager;
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
 use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 
 class ContextManager extends BaseEntityManager implements ContextManagerInterface
 {

--- a/src/Entity/TagManager.php
+++ b/src/Entity/TagManager.php
@@ -12,9 +12,9 @@
 namespace Sonata\ClassificationBundle\Entity;
 
 use Sonata\ClassificationBundle\Model\TagManagerInterface;
-use Sonata\Doctrine\Entity\BaseEntityManager;
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
 use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 
 class TagManager extends BaseEntityManager implements TagManagerInterface
 {

--- a/src/Entity/TagManager.php
+++ b/src/Entity/TagManager.php
@@ -12,7 +12,7 @@
 namespace Sonata\ClassificationBundle\Entity;
 
 use Sonata\ClassificationBundle\Model\TagManagerInterface;
-use Sonata\CoreBundle\Model\BaseEntityManager;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
 use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
 

--- a/src/Form/Type/CategorySelectorType.php
+++ b/src/Form/Type/CategorySelectorType.php
@@ -15,7 +15,7 @@ use Sonata\AdminBundle\Form\Type\ModelType;
 use Sonata\ClassificationBundle\Form\ChoiceList\CategoryChoiceLoader;
 use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
-use Sonata\CoreBundle\Model\ManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;

--- a/src/Model/CategoryManagerInterface.php
+++ b/src/Model/CategoryManagerInterface.php
@@ -11,8 +11,8 @@
 
 namespace Sonata\ClassificationBundle\Model;
 
-use Sonata\CoreBundle\Model\ManagerInterface;
-use Sonata\CoreBundle\Model\PageableManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
+use Sonata\Doctrine\Model\PageableManagerInterface;
 
 interface CategoryManagerInterface extends ManagerInterface, PageableManagerInterface
 {

--- a/src/Model/CollectionManagerInterface.php
+++ b/src/Model/CollectionManagerInterface.php
@@ -11,8 +11,8 @@
 
 namespace Sonata\ClassificationBundle\Model;
 
-use Sonata\CoreBundle\Model\ManagerInterface;
-use Sonata\CoreBundle\Model\PageableManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
+use Sonata\Doctrine\Model\PageableManagerInterface;
 
 interface CollectionManagerInterface extends ManagerInterface, PageableManagerInterface
 {

--- a/src/Model/ContextManagerInterface.php
+++ b/src/Model/ContextManagerInterface.php
@@ -11,8 +11,8 @@
 
 namespace Sonata\ClassificationBundle\Model;
 
-use Sonata\CoreBundle\Model\ManagerInterface;
-use Sonata\CoreBundle\Model\PageableManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
+use Sonata\Doctrine\Model\PageableManagerInterface;
 
 interface ContextManagerInterface extends ManagerInterface, PageableManagerInterface
 {

--- a/src/Model/TagManagerInterface.php
+++ b/src/Model/TagManagerInterface.php
@@ -11,8 +11,8 @@
 
 namespace Sonata\ClassificationBundle\Model;
 
-use Sonata\CoreBundle\Model\ManagerInterface;
-use Sonata\CoreBundle\Model\PageableManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
+use Sonata\Doctrine\Model\PageableManagerInterface;
 
 interface TagManagerInterface extends ManagerInterface, PageableManagerInterface
 {

--- a/tests/Form/Type/CategorySelectorTypeTest.php
+++ b/tests/Form/Type/CategorySelectorTypeTest.php
@@ -13,7 +13,7 @@ namespace Sonata\ClassificationBundle\Tests\Form\Type;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\ClassificationBundle\Form\Type\CategorySelectorType;
-use Sonata\CoreBundle\Model\ManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
 use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 


### PR DESCRIPTION
## Subject

Fixed deprecations warnings from SonataCore.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because  is for deprecation removals, but doesn't have any break change.

## Changelog

```markdown
### Fixed
- Deprecations about `Sonata\CoreBundle\Model\BaseEntityManager`
```

