### PR TITLE
CategoryAdmin labels translations in HU/FR/EN

### DIFF
--- a/src/Admin/CategoryAdmin.php
+++ b/src/Admin/CategoryAdmin.php
@@ -68,7 +68,7 @@ EOT
     protected function configureFormFields(FormMapper $formMapper)
     {
         $formMapper
-            ->with('General', ['class' => 'col-md-6'])
+            ->with('group_general', ['class' => 'col-md-6'])
                 ->add('name')
                 ->add('description', TextareaType::class, [
                     'required' => false,
@@ -93,7 +93,7 @@ EOT
 
         $formMapper
             ->end()
-            ->with('Options', ['class' => 'col-md-6'])
+            ->with('group_options', ['class' => 'col-md-6'])
                 ->add('enabled', CheckboxType::class, [
                     'required' => false,
                 ])
@@ -106,7 +106,7 @@ EOT
 
         if (interface_exists(MediaInterface::class)) {
             $formMapper
-                ->with('General')
+                ->with('group_general')
                     ->add('media', ModelListType::class, [
                         'required' => false,
                     ], [

--- a/src/Resources/translations/SonataClassificationBundle.de.xliff
+++ b/src/Resources/translations/SonataClassificationBundle.de.xliff
@@ -210,6 +210,14 @@
                 <source>form.label_class</source>
                 <target>CSS Klasse</target>
             </trans-unit>
+            <trans-unit id="group_general">
+                <source>group_general</source>
+                <target>Allgemein</target>
+            </trans-unit>
+            <trans-unit id="group_options">
+                <source>group_options</source>
+                <target>Optionen</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataClassificationBundle.en.xliff
+++ b/src/Resources/translations/SonataClassificationBundle.en.xliff
@@ -234,6 +234,14 @@
                 <source>form.label_class</source>
                 <target>CSS Class</target>
             </trans-unit>
+            <trans-unit id="group_general">
+                <source>group_general</source>
+                <target>General</target>
+            </trans-unit>
+            <trans-unit id="group_options">
+                <source>group_options</source>
+                <target>Options</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataClassificationBundle.fr.xliff
+++ b/src/Resources/translations/SonataClassificationBundle.fr.xliff
@@ -226,6 +226,14 @@
                 <source>form.label_class</source>
                 <target>Classe CSS</target>
             </trans-unit>
+            <trans-unit id="group_general">
+                <source>group_general</source>
+                <target>Général</target>
+            </trans-unit>
+            <trans-unit id="group_options">
+                <source>group_options</source>
+                <target>Options</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataClassificationBundle.hu.xliff
+++ b/src/Resources/translations/SonataClassificationBundle.hu.xliff
@@ -198,6 +198,14 @@
                 <source>no_tags_found</source>
                 <target>Címke nem található</target>
             </trans-unit>
+            <trans-unit id="group_general">
+                <source>group_general</source>
+                <target>Általános</target>
+            </trans-unit>
+            <trans-unit id="group_options">
+                <source>group_options</source>
+                <target>Opciók</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I want to translate General and Options label in CategoryAdmin in HU/FR/EN.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataClassificationBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added CategoryAdmin General and Options labels translations 
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
