### PR TITLE
Deprecate passing context as string to manger methods

### DIFF
--- a/src/Entity/CategoryManager.php
+++ b/src/Entity/CategoryManager.php
@@ -274,12 +274,19 @@ class CategoryManager extends BaseEntityManager implements CategoryManagerInterf
     }
 
     /**
-     * @param string|ContextInterface $contextCode
+     * @param ContextInterface|null $contextCode
      *
      * @return ContextInterface
      */
     private function getContext($contextCode)
     {
+        if (\is_string($contextCode)) {
+            @trigger_error(
+                'Passing a string as context is deprecated since sonata-project/classification-bundle 3.x, to be forbidden in 4.0.',
+                E_USER_DEPRECATED
+            );
+        }
+
         if (empty($contextCode)) {
             $contextCode = ContextInterface::DEFAULT_CONTEXT;
         }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

All public methods require a `ContextInterface` as context parameter, so we should deprecate all other values. 

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #299

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataClassificationBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecate passing context as string to manger methods
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
