### PR TITLE
Update CategoryManager.php

### DIFF
--- a/src/Entity/CategoryManager.php
+++ b/src/Entity/CategoryManager.php
@@ -293,18 +293,18 @@ class CategoryManager extends BaseEntityManager implements CategoryManagerInterf
             ));
         }
 
-        $context = $this->contextManager->find($context);
+        $contextObj = $this->contextManager->find($context);
 
-        if (!$context instanceof ContextInterface) {
-            $context = $this->contextManager->create();
+        if (!$contextObj instanceof ContextInterface) {
+            $contextObj = $this->contextManager->create();
 
-            $context->setId($context);
-            $context->setName($context);
-            $context->setEnabled(true);
+            $contextObj->setId($context);
+            $contextObj->setName($context);
+            $contextObj->setEnabled(true);
 
-            $this->contextManager->save($context);
+            $this->contextManager->save($contextObj);
         }
 
-        return $context;
+        return $contextObj;
     }
 }


### PR DESCRIPTION
## Subject

getContext caused name/id to be self-recursiveI am targeting this branch, because this is backwards-compatible.

Closes #470, #472 

## Changelog

```markdown
### Fixed
- `getContext` method with non-existing one causing self-recursiveness
```