### PR TITLE
Leverage `$this` binding at class scoped closures

### DIFF
--- a/src/Form/Type/CategorySelectorType.php
+++ b/src/Form/Type/CategorySelectorType.php
@@ -19,6 +19,7 @@ use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\Doctrine\Model\ManagerInterface;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -52,13 +53,11 @@ class CategorySelectorType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver)
     {
-        $that = $this;
-
         $resolver->setDefaults([
             'context' => null,
             'category' => null,
-            'choice_loader' => static function (Options $opts, $previousValue) use ($that) {
-                return new CategoryChoiceLoader(array_flip($that->getChoices($opts)));
+            'choice_loader' => function (Options $opts): ChoiceLoaderInterface {
+                return new CategoryChoiceLoader(array_flip($this->getChoices($opts)));
             },
         ]);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Leverage `$this` binding at class scoped closures
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
[ref.](https://www.php.net/manual/en/functions.anonymous.php):
>As of PHP 5.4.0, when declared in the context of a class, the current class is automatically bound to it, making $this available inside of the function's scope. If this automatic binding of the current class is not wanted, then static anonymous functions may be used instead.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Static closure to regular one in order to use `$this` from the class scope.
```
