### PR TITLE
invalid xml mapping file (mongodb)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
     "require": {
         "php": "^7.1",
         "cocur/slugify": "^2.0 || ^3.0",
-        "doctrine/mongodb-odm": "^2.0",
         "sonata-project/admin-bundle": "^3.31",
         "sonata-project/core-bundle": "^3.14",
         "sonata-project/datagrid-bundle": "^2.3",
@@ -40,11 +39,13 @@
         "twig/twig": "^1.35 || ^2.0"
     },
     "conflict": {
+        "doctrine/mongodb-odm": "<2.0",
         "friendsofsymfony/rest-bundle": "<2.1 || >=3.0",
         "jms/serializer": "<0.13",
         "sonata-project/block-bundle": "<3.14 || >=4.0"
     },
     "require-dev": {
+        "doctrine/mongodb-odm": "^2.0",
         "friendsofsymfony/rest-bundle": "^2.1",
         "jms/serializer-bundle": "^1.0 || ^2.0",
         "sonata-project/block-bundle": "^3.14",

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "require": {
         "php": "^7.1",
         "cocur/slugify": "^2.0 || ^3.0",
+        "doctrine/mongodb-odm": "^2.0",
         "sonata-project/admin-bundle": "^3.31",
         "sonata-project/core-bundle": "^3.14",
         "sonata-project/datagrid-bundle": "^2.3",

--- a/src/Resources/config/doctrine/BaseCategory.mongodb.xml
+++ b/src/Resources/config/doctrine/BaseCategory.mongodb.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping                   http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
-  <mapped-superclass name="Sonata\ClassificationBundle\Document\BaseCategory">
-    <field name="name" type="string" field-name="name"/>
-    <field name="enabled" type="boolean" field-name="enabled"/>
-    <field name="slug" type="string" field-name="slug"/>
-    <field name="description" type="string" field-name="description"/>
-    <field name="position" type="integer" field-name="position"/>
-    <field name="createdAt" type="timestamp" field-name="createdAt"/>
-    <field name="updatedAt" type="timestamp" field-name="updatedAt"/>
-    <lifecycle-callbacks>
-      <lifecycle-callback type="prePersist" method="prePersist"/>
-      <lifecycle-callback type="preUpdate" method="preUpdate"/>
-    </lifecycle-callbacks>
-  </mapped-superclass>
+    <mapped-superclass name="Sonata\ClassificationBundle\Document\BaseCategory">
+        <field name="name" type="string" field-name="name"/>
+        <field name="enabled" type="boolean" field-name="enabled"/>
+        <field name="slug" type="string" field-name="slug"/>
+        <field name="description" type="string" field-name="description"/>
+        <field name="position" type="integer" field-name="position"/>
+        <field name="createdAt" type="timestamp" field-name="createdAt"/>
+        <field name="updatedAt" type="timestamp" field-name="updatedAt"/>
+        <lifecycle-callbacks>
+            <lifecycle-callback type="prePersist" method="prePersist"/>
+            <lifecycle-callback type="preUpdate" method="preUpdate"/>
+        </lifecycle-callbacks>
+    </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/src/Resources/config/doctrine/BaseCategory.mongodb.xml
+++ b/src/Resources/config/doctrine/BaseCategory.mongodb.xml
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
-                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
-                  http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
-    <mapped-superclass name="Sonata\ClassificationBundle\Document\BaseCategory">
-        <field name="name" type="string" field-name="name"/>
-        <field name="enabled" type="boolean" field-name="enabled"/>
-        <field name="slug" type="string" field-name="slug"/>
-        <field name="description" type="string" field-name="description"/>
-        <field name="position" type="integer" field-name="position"/>
-        <field name="createdAt" type="timestamp" field-name="createdAt"/>
-        <field name="updatedAt" type="timestamp" field-name="updatedAt"/>
-        <lifecycle-callbacks>
-            <lifecycle-callback type="prePersist" method="prePersist"/>
-            <lifecycle-callback type="preUpdate" method="preUpdate"/>
-        </lifecycle-callbacks>
-    </mapped-superclass>
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping                   http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+  <mapped-superclass name="Sonata\ClassificationBundle\Document\BaseCategory">
+    <field name="name" type="string" field-name="name"/>
+    <field name="enabled" type="boolean" field-name="enabled"/>
+    <field name="slug" type="string" field-name="slug"/>
+    <field name="description" type="string" field-name="description"/>
+    <field name="position" type="integer" field-name="position"/>
+    <field name="createdAt" type="timestamp" field-name="createdAt"/>
+    <field name="updatedAt" type="timestamp" field-name="updatedAt"/>
+    <lifecycle-callbacks>
+      <lifecycle-callback type="prePersist" method="prePersist"/>
+      <lifecycle-callback type="preUpdate" method="preUpdate"/>
+    </lifecycle-callbacks>
+  </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/src/Resources/config/doctrine/BaseCategory.mongodb.xml
+++ b/src/Resources/config/doctrine/BaseCategory.mongodb.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping                     http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping.xsd">
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                  http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
     <mapped-superclass name="Sonata\ClassificationBundle\Document\BaseCategory">
-        <field name="name" type="string" fieldName="name"/>
-        <field name="enabled" type="boolean" fieldName="enabled"/>
-        <field name="slug" type="string" fieldName="slug"/>
-        <field name="description" type="string" fieldName="description"/>
-        <field name="createdAt" type="timestamp" fieldName="createdAt"/>
-        <field name="updatedAt" type="timestamp" fieldName="updatedAt"/>
+        <field name="name" type="string" field-name="name"/>
+        <field name="enabled" type="boolean" field-name="enabled"/>
+        <field name="slug" type="string" field-name="slug"/>
+        <field name="description" type="string" field-name="description"/>
+        <field name="position" type="integer" field-name="position"/>
+        <field name="createdAt" type="timestamp" field-name="createdAt"/>
+        <field name="updatedAt" type="timestamp" field-name="updatedAt"/>
         <lifecycle-callbacks>
             <lifecycle-callback type="prePersist" method="prePersist"/>
             <lifecycle-callback type="preUpdate" method="preUpdate"/>

--- a/src/Resources/config/doctrine/BaseContext.mongodb.xml
+++ b/src/Resources/config/doctrine/BaseContext.mongodb.xml
@@ -1,16 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
-                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
-                  http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
-    <mapped-superclass name="Sonata\ClassificationBundle\Document\BaseContext">
-        <field name="name" type="string" field-name="name"/>
-        <field name="enabled" type="boolean" field-name="enabled"/>
-        <field name="createdAt" type="timestamp" field-name="createdAt"/>
-        <field name="updatedAt" type="timestamp" field-name="updatedAt"/>
-        <lifecycle-callbacks>
-            <lifecycle-callback type="prePersist" method="prePersist"/>
-            <lifecycle-callback type="preUpdate" method="preUpdate"/>
-        </lifecycle-callbacks>
-    </mapped-superclass>
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping                   http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+  <mapped-superclass name="Sonata\ClassificationBundle\Document\BaseContext">
+    <field name="name" type="string" field-name="name"/>
+    <field name="enabled" type="boolean" field-name="enabled"/>
+    <field name="createdAt" type="timestamp" field-name="createdAt"/>
+    <field name="updatedAt" type="timestamp" field-name="updatedAt"/>
+    <lifecycle-callbacks>
+      <lifecycle-callback type="prePersist" method="prePersist"/>
+      <lifecycle-callback type="preUpdate" method="preUpdate"/>
+    </lifecycle-callbacks>
+  </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/src/Resources/config/doctrine/BaseContext.mongodb.xml
+++ b/src/Resources/config/doctrine/BaseContext.mongodb.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping                   http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
-  <mapped-superclass name="Sonata\ClassificationBundle\Document\BaseContext">
-    <field name="name" type="string" field-name="name"/>
-    <field name="enabled" type="boolean" field-name="enabled"/>
-    <field name="createdAt" type="timestamp" field-name="createdAt"/>
-    <field name="updatedAt" type="timestamp" field-name="updatedAt"/>
-    <lifecycle-callbacks>
-      <lifecycle-callback type="prePersist" method="prePersist"/>
-      <lifecycle-callback type="preUpdate" method="preUpdate"/>
-    </lifecycle-callbacks>
-  </mapped-superclass>
+    <mapped-superclass name="Sonata\ClassificationBundle\Document\BaseContext">
+        <field name="name" type="string" field-name="name"/>
+        <field name="enabled" type="boolean" field-name="enabled"/>
+        <field name="createdAt" type="timestamp" field-name="createdAt"/>
+        <field name="updatedAt" type="timestamp" field-name="updatedAt"/>
+        <lifecycle-callbacks>
+            <lifecycle-callback type="prePersist" method="prePersist"/>
+            <lifecycle-callback type="preUpdate" method="preUpdate"/>
+        </lifecycle-callbacks>
+    </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/src/Resources/config/doctrine/BaseContext.mongodb.xml
+++ b/src/Resources/config/doctrine/BaseContext.mongodb.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping                     http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping.xsd">
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                  http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
     <mapped-superclass name="Sonata\ClassificationBundle\Document\BaseContext">
-        <field name="name" type="string" column="name"/>
-        <field name="enabled" type="boolean" fieldName="enabled"/>
-        <field name="createdAt" type="timestamp" fieldName="createdAt"/>
-        <field name="updatedAt" type="timestamp" fieldName="updatedAt"/>
+        <field name="name" type="string" field-name="name"/>
+        <field name="enabled" type="boolean" field-name="enabled"/>
+        <field name="createdAt" type="timestamp" field-name="createdAt"/>
+        <field name="updatedAt" type="timestamp" field-name="updatedAt"/>
         <lifecycle-callbacks>
             <lifecycle-callback type="prePersist" method="prePersist"/>
             <lifecycle-callback type="preUpdate" method="preUpdate"/>

--- a/src/Resources/config/doctrine/BaseTag.mongodb.xml
+++ b/src/Resources/config/doctrine/BaseTag.mongodb.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping                   http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
-  <mapped-superclass name="Sonata\ClassificationBundle\Document\BaseTag">
-    <field name="name" type="string" field-name="name"/>
-    <field name="enabled" type="boolean" field-name="enabled"/>
-    <field name="slug" type="string" field-name="slug"/>
-    <field name="createdAt" type="timestamp" field-name="createdAt"/>
-    <field name="updatedAt" type="timestamp" field-name="updatedAt"/>
-    <lifecycle-callbacks>
-      <lifecycle-callback type="prePersist" method="prePersist"/>
-      <lifecycle-callback type="preUpdate" method="preUpdate"/>
-    </lifecycle-callbacks>
-  </mapped-superclass>
+    <mapped-superclass name="Sonata\ClassificationBundle\Document\BaseTag">
+        <field name="name" type="string" field-name="name"/>
+        <field name="enabled" type="boolean" field-name="enabled"/>
+        <field name="slug" type="string" field-name="slug"/>
+        <field name="createdAt" type="timestamp" field-name="createdAt"/>
+        <field name="updatedAt" type="timestamp" field-name="updatedAt"/>
+        <lifecycle-callbacks>
+            <lifecycle-callback type="prePersist" method="prePersist"/>
+            <lifecycle-callback type="preUpdate" method="preUpdate"/>
+        </lifecycle-callbacks>
+    </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/src/Resources/config/doctrine/BaseTag.mongodb.xml
+++ b/src/Resources/config/doctrine/BaseTag.mongodb.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping                     http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping.xsd">
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                  http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
     <mapped-superclass name="Sonata\ClassificationBundle\Document\BaseTag">
-        <field name="name" type="string" fieldName="name"/>
-        <field name="enabled" type="boolean" fieldName="enabled"/>
-        <field name="slug" type="string" fieldName="slug"/>
-        <field name="createdAt" type="timestamp" fieldName="createdAt"/>
-        <field name="updatedAt" type="timestamp" fieldName="updatedAt"/>
+        <field name="name" type="string" field-name="name"/>
+        <field name="enabled" type="boolean" field-name="enabled"/>
+        <field name="slug" type="string" field-name="slug"/>
+        <field name="createdAt" type="timestamp" field-name="createdAt"/>
+        <field name="updatedAt" type="timestamp" field-name="updatedAt"/>
         <lifecycle-callbacks>
             <lifecycle-callback type="prePersist" method="prePersist"/>
             <lifecycle-callback type="preUpdate" method="preUpdate"/>

--- a/src/Resources/config/doctrine/BaseTag.mongodb.xml
+++ b/src/Resources/config/doctrine/BaseTag.mongodb.xml
@@ -1,17 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
-                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
-                  http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
-    <mapped-superclass name="Sonata\ClassificationBundle\Document\BaseTag">
-        <field name="name" type="string" field-name="name"/>
-        <field name="enabled" type="boolean" field-name="enabled"/>
-        <field name="slug" type="string" field-name="slug"/>
-        <field name="createdAt" type="timestamp" field-name="createdAt"/>
-        <field name="updatedAt" type="timestamp" field-name="updatedAt"/>
-        <lifecycle-callbacks>
-            <lifecycle-callback type="prePersist" method="prePersist"/>
-            <lifecycle-callback type="preUpdate" method="preUpdate"/>
-        </lifecycle-callbacks>
-    </mapped-superclass>
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping                   http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+  <mapped-superclass name="Sonata\ClassificationBundle\Document\BaseTag">
+    <field name="name" type="string" field-name="name"/>
+    <field name="enabled" type="boolean" field-name="enabled"/>
+    <field name="slug" type="string" field-name="slug"/>
+    <field name="createdAt" type="timestamp" field-name="createdAt"/>
+    <field name="updatedAt" type="timestamp" field-name="updatedAt"/>
+    <lifecycle-callbacks>
+      <lifecycle-callback type="prePersist" method="prePersist"/>
+      <lifecycle-callback type="preUpdate" method="preUpdate"/>
+    </lifecycle-callbacks>
+  </mapped-superclass>
 </doctrine-mongo-mapping>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

In a Symfony 4.3.8 project, when we update the `doctrine/mongodb-odm` and `doctrine/mongodb-odm-bundle` packages in their latest version, the following error appears: 
> The mapping file /var/www/project/vendor/sonata-project/classification-bundle/src/Resources/config/doctrine/BaseTag.mongodb.xml is invalid: Line 2:0: Element '{http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping}doctrine-mongo-mapping': No matching global declaration available for the validation root.

```
        "doctrine/mongodb-odm": "^2.0",
        "doctrine/mongodb-odm-bundle": "^4.0",
```

http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping.xsd (404) is not valid, new url seems http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd

I don't know which branch to target, I think it's `master` in this case. Need Help

Related issue:
- https://github.com/sonata-project/SonataUserBundle/issues/1120

Related documentation:
- https://www.doctrine-project.org/projects/doctrine-mongodb-odm/en/2.0/reference/basic-mapping.html _(check xml tabs)_
- https://github.com/doctrine/mongodb-odm/blob/master/UPGRADE-2.0.md#xml-mapping

## Changelog

```
### Fixed
- Fix invalid Mongodb mapping files (mongodb-odm >= 2.0)
```

### Screenshots

![Screenshot 2019-11-18 at 15 56 50](https://user-images.githubusercontent.com/7681951/69064172-0bb61380-0a1e-11ea-9f78-b37b35fe64f0.jpg)

### To Reproduce / configuration:

`composer.json`
<details>

```
"require": {
        "php": ">=7.3",
        "ext-ftp": "*",
        "ext-igbinary": "*",
        "ext-json": "*",
        "ext-mongodb": "*",
        "ext-pcntl": "*",
        "ext-posix": "*",
        "ext-redis": "*",
        "ext-soap": "*",
        "adoy/oauth2": "dev-master",
        "alcaeus/mongo-php-adapter": "^1.1",
        "azuyalabs/yasumi": "^2.0",
        "beberlei/doctrineextensions": "^1.1",
        "cocur/slugify": "^3.2",
        "datadog/php-datadogstatsd": "^1.3",
        "doctrine/dbal": "^2.9",
        "doctrine/doctrine-bundle": "^1.11",
        "doctrine/doctrine-cache-bundle": "^1.3",
        "doctrine/doctrine-migrations-bundle": "^2.0",
        "doctrine/mongodb-odm": "^2.0",
        "doctrine/mongodb-odm-bundle": "^4.0",
        "doctrine/orm": "^2.5",
        "donatj/phpuseragentparser": "^0.13.0",
        "egulias/email-validator": "^2.1",
        "elasticsearch/elasticsearch": "^6.1",
        "fightbulc/moment": "^1.25",
        "florianv/exchanger": "1.4.1",
        "florianv/swap": "^3.4",
        "friendsofsymfony/elastica-bundle": "^5.1",
        "friendsofsymfony/jsrouting-bundle": "^2.3",
        "friendsofsymfony/rest-bundle": "^2.5",
        "gedmo/doctrine-extensions": "~2.4",
        "geoip2/geoip2": "~2.0",
        "google/apiclient": "^2.0",
        "googleads/googleads-php-lib": "^43.0",
        "guzzlehttp/guzzle": "^6.3",
        "hashids/hashids": "^4.0",
        "hutnikau/job-scheduler": "^0.6",
        "knplabs/knp-menu": "~2.0",
        "knplabs/knp-paginator-bundle": "^3.0",
        "league/oauth1-client": "^1.7",
        "league/uri": "^5.3",
        "microsoft/bingads": "^v0.12.13",
        "mobiledetect/mobiledetectlib": "^2.8",
        "monolog/monolog": "^2.0.0 || ^1.17.1",
        "nesbot/carbon": "^2.11",
        "ocramius/doctrine-batch-utils": "^2.0",
        "php-http/guzzle6-adapter": "^2.0",
        "php-http/httplug-bundle": "^1.15",
        "php-http/message": "^1.6",
        "phpoffice/phpspreadsheet": "^1.6",
        "phpseclib/phpseclib": "^2.0",
        "portphp/csv": "^1.1",
        "portphp/excel": "^1.1",
        "portphp/portphp": "^1.3",
        "predis/predis": "^1.1",
        "ramsey/uuid": "^3.8",
        "rollerworks/password-strength-validator": "^1.1",
        "scienta/doctrine-json-functions": "^4.0",
        "sensio/framework-extra-bundle": "^5.3",
        "snc/redis-bundle": "^3.1",
        "sonata-project/admin-bundle": "^3.0",
        "sonata-project/classification-bundle": "^3.8",
        "sonata-project/doctrine-mongodb-admin-bundle": "^3.2",
        "sonata-project/doctrine-orm-admin-bundle": "^3.8",
        "sonata-project/exporter": "^2.0.1",
        "sonata-project/formatter-bundle": "^4.1",
        "sonata-project/intl-bundle": "^2.5",
        "sonata-project/media-bundle": "^3.0",
        "sonata-project/translation-bundle": "^2.0",
        "spatie/data-transfer-object": "^1.6",
        "stof/doctrine-extensions-bundle": "~1.1",
        "symfony/asset": "^4.2",
        "symfony/dotenv": "^4.2",
        "symfony/flex": "^1.2",
        "symfony/form": "^4.2",
        "symfony/lock": "^4.2",
        "symfony/monolog-bundle": "^3.4",
        "symfony/process": "^4.2",
        "symfony/security-bundle": "^4.2",
        "symfony/serializer": "^4.3",
        "symfony/swiftmailer-bundle": "^3.2",
        "symfony/translation": "^4.2",
        "symfony/twig-bundle": "^4.2",
        "symfony/validator": "^4.2",
        "symfony/webpack-encore-bundle": "^1.4",
        "twig/extensions": "^1.5",
        "twig/twig": "^2.6",
        "willdurand/jsonp-callback-validator": "^1.1"
    },
    "require-dev": {
        "ext-libxml": "*",
        "ext-simplexml": "*",
        "doctrine/data-fixtures": "^1.3",
        "doctrine/doctrine-fixtures-bundle": "^3.1",
        "friendsofphp/php-cs-fixer": "^2.15",
        "fzaninotto/faker": "^1.7",
        "hoa/regex": "^1.17",
        "mockery/mockery": "^1.2",
        "nelmio/alice": "^3.5",
        "phpstan/phpstan": "^0.11",
        "phpstan/phpstan-doctrine": "^0.11",
        "phpunit/phpunit": "^8.3",
        "roave/security-advisories": "dev-master",
        "rg/phpnsc": "^5.0",
        "spatie/phpunit-snapshot-assertions": "^2.1",
        "spatie/phpunit-watcher": "^1.6",
        "symfony/browser-kit": "^4.2",
        "symfony/css-selector": "^4.2",
        "symfony/debug-bundle": "^4.2",
        "symfony/maker-bundle": "^1.11",
        "symfony/orm-pack": "^1.0",
        "symfony/phpunit-bridge": "^4.2",
        "symfony/var-dumper": "^4.2",
        "symfony/web-profiler-bundle": "^4.2",
        "theofidry/alice-data-fixtures": "^1.1"
    },
```

</details>