### PR TITLE
Fix media bundle decoupling

### DIFF
--- a/src/DependencyInjection/SonataClassificationExtension.php
+++ b/src/DependencyInjection/SonataClassificationExtension.php
@@ -196,7 +196,7 @@ class SonataClassificationExtension extends Extension
 
         $collector->addUnique($config['class']['collection'], 'tag_collection', ['slug', 'context']);
 
-        if (null === $config['class']['media']) {
+        if (null !== $config['class']['media']) {
             $collector->addAssociation($config['class']['collection'], 'mapManyToOne', [
                 'fieldName' => 'media',
                 'targetEntity' => $config['class']['media'],


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

There is stupid bug in the last PR #490.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes #490 
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataClassificationBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- Fix media bundle decoupling
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
