### PR TITLE
Allow cocur/slugify ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "cocur/slugify": "^2.0 || ^3.0",
+        "cocur/slugify": "^2.0 || ^3.0 || ^4.0",
         "sonata-project/admin-bundle": "^3.31",
         "sonata-project/core-bundle": "^3.14",
         "sonata-project/datagrid-bundle": "^2.3",


### PR DESCRIPTION
## Subject

Version 4 does not introduce new major features, but adds support for Symfony 4 and 5, Twig 3 and, most importantly, PHP 7.3 and 7.4.

I am targeting this branch, because this change is backward compatible.

## Changelog

```markdown
### Fixed
- Allow "cocur/slugify" ^4.0
```