### PR TITLE
Add admin filters

### DIFF
--- a/src/Admin/Filter/CategoryFilter.php
+++ b/src/Admin/Filter/CategoryFilter.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Admin\Filter;
+
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
+use Sonata\ClassificationBundle\Model\CategoryInterface;
+use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
+use Sonata\DoctrineORMAdminBundle\Filter\Filter;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+
+final class CategoryFilter extends Filter
+{
+    /**
+     * @var CategoryManagerInterface
+     */
+    private $categoryManager;
+
+    public function __construct(CategoryManagerInterface $categoryManager)
+    {
+        $this->categoryManager = $categoryManager;
+    }
+
+    public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data): void
+    {
+        if (null === $data || !\is_array($data) || !\array_key_exists('value', $data)) {
+            return;
+        }
+
+        if (null !== $data['value']) {
+            $queryBuilder
+                ->andWhere(sprintf('%s.%s = :category', $alias, $field))
+                ->setParameter('category', $data['value'])
+            ;
+        }
+
+        $this->active = null !== $data['value'];
+    }
+
+    public function getDefaultOptions(): array
+    {
+        return [
+            'context' => null,
+        ];
+    }
+
+    public function getFieldType(): string
+    {
+        return $this->getOption('field_type', ChoiceType::class);
+    }
+
+    public function getFieldOptions(): array
+    {
+        return $this->getOption('choices', [
+            'choices' => $this->getChoices(),
+            'choice_translation_domain' => false,
+        ]);
+    }
+
+    public function getRenderSettings(): array
+    {
+        return [DefaultType::class, [
+            'field_type' => $this->getFieldType(),
+            'field_options' => $this->getFieldOptions(),
+            'label' => $this->getLabel(),
+        ]];
+    }
+
+    protected function association(ProxyQueryInterface $queryBuilder, $data): array
+    {
+        $alias = $queryBuilder->entityJoin($this->getParentAssociationMappings());
+        $part = strrchr('.'.$this->getFieldName(), '.');
+        $fieldName = substr(false === $part ? $this->getFieldType() : $part, 1);
+
+        return [$alias, $fieldName];
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function getChoices(): array
+    {
+        $context = $this->getOption('context');
+
+        if (null === $context) {
+            $categories = $this->categoryManager->getAllRootCategories();
+        } else {
+            $categories = $this->categoryManager->getRootCategoriesForContext($context);
+        }
+
+        $choices = [];
+
+        foreach ($categories as $category) {
+            $choices[sprintf('%s (%s)', $category->getName(), $category->getContext()->getId())] = $category->getId();
+
+            $this->visitChild($category, $choices);
+        }
+
+        return $choices;
+    }
+
+    private function visitChild(CategoryInterface $category, array &$choices, int $level = 2): void
+    {
+        if (0 === \count($category->getChildren())) {
+            return;
+        }
+
+        foreach ($category->getChildren() as $child) {
+            $choices[sprintf('%s %s', str_repeat('-', 1 * $level), (string) $child)] = $child->getId();
+
+            $this->visitChild($child, $choices, $level + 1);
+        }
+    }
+}

--- a/src/Admin/Filter/CollectionFilter.php
+++ b/src/Admin/Filter/CollectionFilter.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Admin\Filter;
+
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
+use Sonata\ClassificationBundle\Model\CollectionManagerInterface;
+use Sonata\DoctrineORMAdminBundle\Filter\Filter;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+
+final class CollectionFilter extends Filter
+{
+    /**
+     * @var CollectionManagerInterface
+     */
+    private $collectionManager;
+
+    public function __construct(CollectionManagerInterface $collectionManager)
+    {
+        $this->collectionManager = $collectionManager;
+    }
+
+    public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data): void
+    {
+        if (null === $data || !\is_array($data) || !\array_key_exists('value', $data)) {
+            return;
+        }
+
+        if ($data['value']) {
+            $queryBuilder
+                ->andWhere(sprintf('%s.%s = :collection', $alias, $field))
+                ->setParameter('collection', $data['value'])
+            ;
+        }
+
+        $this->active = null !== $data['value'];
+    }
+
+    public function getDefaultOptions(): array
+    {
+        return [
+            'context' => null,
+        ];
+    }
+
+    public function getFieldType(): string
+    {
+        return $this->getOption('field_type', ChoiceType::class);
+    }
+
+    public function getFieldOptions(): array
+    {
+        return $this->getOption('choices', [
+            'choices' => $this->getChoices(),
+            'choice_translation_domain' => false,
+        ]);
+    }
+
+    public function getRenderSettings(): array
+    {
+        return [DefaultType::class, [
+            'field_type' => $this->getFieldType(),
+            'field_options' => $this->getFieldOptions(),
+            'label' => $this->getLabel(),
+        ]];
+    }
+
+    protected function association(ProxyQueryInterface $queryBuilder, $data): array
+    {
+        $alias = $queryBuilder->entityJoin($this->getParentAssociationMappings());
+        $part = strrchr('.'.$this->getFieldName(), '.');
+        $fieldName = substr(false === $part ? $this->getFieldType() : $part, 1);
+
+        return [$alias, $fieldName];
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function getChoices(): array
+    {
+        $context = $this->getOption('context');
+
+        if (null === $context) {
+            $collections = $this->collectionManager->findAll();
+        } else {
+            $collections = $this->collectionManager->getByContext($context);
+        }
+
+        $choices = [];
+
+        foreach ($collections as $collection) {
+            $choices[(string) $collection] = $collection->getId();
+        }
+
+        return $choices;
+    }
+}

--- a/src/Resources/config/admin.xml
+++ b/src/Resources/config/admin.xml
@@ -50,5 +50,13 @@
                 <argument>%sonata.classification.admin.context.translation_domain%</argument>
             </call>
         </service>
+        <service id="Sonata\ClassificationBundle\Admin\Filter\CategoryFilter">
+            <tag name="sonata.admin.filter.type"/>
+            <argument type="service" id="sonata.classification.manager.category"/>
+        </service>
+        <service id="Sonata\ClassificationBundle\Admin\Filter\CollectionFilter">
+            <tag name="sonata.admin.filter.type"/>
+            <argument type="service" id="sonata.classification.manager.collection"/>
+        </service>
     </services>
 </container>

--- a/tests/Admin/Filter/CategoryFilterTest.php
+++ b/tests/Admin/Filter/CategoryFilterTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Tests\Admin\Filter;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\ClassificationBundle\Admin\Filter\CategoryFilter;
+use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+
+class CategoryFilterTest extends TestCase
+{
+    /**
+     * @var MockObject&CategoryManagerInterface
+     */
+    private $categoryManager;
+
+    protected function setUp(): void
+    {
+        $this->categoryManager = $this->createStub(CategoryManagerInterface::class);
+    }
+
+    public function testRenderSettings(): void
+    {
+        $this->categoryManager->method('getAllRootCategories')->willReturn([]);
+
+        $filter = new CategoryFilter($this->categoryManager);
+        $filter->initialize('field_name', [
+            'field_options' => ['class' => 'FooBar'],
+            ]);
+        $options = $filter->getRenderSettings()[1];
+
+        $this->assertSame(ChoiceType::class, $options['field_type']);
+        $this->assertSame([], $options['field_options']['choices']);
+    }
+}

--- a/tests/Admin/Filter/CollectionFilterTest.php
+++ b/tests/Admin/Filter/CollectionFilterTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Tests\Admin\Filter;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sonata\ClassificationBundle\Admin\Filter\CollectionFilter;
+use Sonata\ClassificationBundle\Model\CollectionManagerInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+
+class CollectionFilterTest extends TestCase
+{
+    /**
+     * @var MockObject&CollectionManagerInterface
+     */
+    private $collectionManager;
+
+    protected function setUp(): void
+    {
+        $this->collectionManager = $this->createStub(CollectionManagerInterface::class);
+    }
+
+    public function testRenderSettings(): void
+    {
+        $this->collectionManager->method('findAll')->willReturn([]);
+
+        $filter = new CollectionFilter($this->collectionManager);
+        $filter->initialize('field_name', [
+            'field_options' => ['class' => 'FooBar'],
+            ]);
+        $options = $filter->getRenderSettings()[1];
+
+        $this->assertSame(ChoiceType::class, $options['field_type']);
+        $this->assertSame([], $options['field_options']['choices']);
+    }
+}

--- a/tests/Admin/Filter/QueryBuilder.php
+++ b/tests/Admin/Filter/QueryBuilder.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Tests\Admin\Filter;
+
+use Doctrine\ORM\Query\Expr\Andx;
+use Doctrine\ORM\Query\Expr\Orx;
+
+final class QueryBuilder extends \Doctrine\ORM\QueryBuilder
+{
+    public $parameters = [];
+
+    public $query = [];
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function setParameter(string $key, $value, $type = null)
+    {
+        $this->parameters[$key] = $value;
+    }
+
+    public function andWhere()
+    {
+        $query = \func_get_args();
+
+        $this->query[] = $query;
+    }
+
+    public function expr(): self
+    {
+        return $this;
+    }
+
+    /**
+     * @param string|string[] $parameter
+     */
+    public function in(string $alias, $parameter): string
+    {
+        if (\is_array($parameter)) {
+            return sprintf('%s IN ("%s")', $alias, implode(', ', $parameter));
+        }
+
+        return sprintf('%s IN %s', $alias, $parameter);
+    }
+
+    public function getDQLPart($queryPart)
+    {
+        return [];
+    }
+
+    public function getRootAlias(): string
+    {
+        return current(($this->getRootAliases()));
+    }
+
+    public function leftJoin($join, $alias, $conditionType = null, $condition = null, $indexBy = null)
+    {
+        $this->query[] = $join;
+    }
+
+    public function orX($x = null): Orx
+    {
+        return new Orx(\func_get_args());
+    }
+
+    public function andX($x = null): Andx
+    {
+        return new Andx(\func_get_args());
+    }
+
+    public function neq(string $alias, string $parameter): string
+    {
+        return sprintf('%s <> %s', $alias, $parameter);
+    }
+
+    public function isNull(string $queryPart): string
+    {
+        return $queryPart.' IS NULL';
+    }
+
+    public function isNotNull(string $queryPart): string
+    {
+        return $queryPart.' IS NOT NULL';
+    }
+
+    /**
+     * @param string|string[] $parameter
+     */
+    public function notIn(string $alias, $parameter): string
+    {
+        if (\is_array($parameter)) {
+            return sprintf('%s NOT IN ("%s")', $alias, implode(', ', $parameter));
+        }
+
+        return sprintf('%s NOT IN %s', $alias, $parameter);
+    }
+
+    public function getAllAliases(): array
+    {
+        return $this->getRootAliases();
+    }
+
+    public function getRootAliases(): array
+    {
+        return ['o'];
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Adds reuseable filters that can respect the admins classification context.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this feature is BC.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataClassificationBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `CategoryFilter` for admin lists
- Added `CollectionFilter` for admin lists
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
