### PR TITLE
Add manager aliases

### DIFF
--- a/src/Resources/config/orm.xml
+++ b/src/Resources/config/orm.xml
@@ -24,5 +24,9 @@
             <argument>%sonata.classification.manager.context.entity%</argument>
             <argument type="service" id="doctrine"/>
         </service>
+        <service id="Sonata\ClassificationBundle\Model\CategoryManagerInterface" alias="sonata.classification.manager.category" public="true"/>
+        <service id="Sonata\ClassificationBundle\Model\TagManagerInterface" alias="sonata.classification.manager.tag" public="true"/>
+        <service id="Sonata\ClassificationBundle\Model\CollectionManagerInterface" alias="sonata.classification.manager.collection" public="true"/>
+        <service id="Sonata\ClassificationBundle\Model\ContextManagerInterface" alias="sonata.classification.manager.context" public="true"/>
     </services>
 </container>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Add public aliases to all manager interface so that they can be used with DI.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataClassificationBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Add public aliases to all manager interface
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
