### PR TITLE
Fix Lexer query error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "sonata-project/admin-bundle": "^3.31",
         "sonata-project/core-bundle": "^3.14",
         "sonata-project/datagrid-bundle": "^2.3",
-        "sonata-project/doctrine-extensions": "^1.5.1",
+        "sonata-project/doctrine-extensions": "^1.6.0",
         "sonata-project/doctrine-orm-admin-bundle": "^3.4",
         "sonata-project/easy-extends-bundle": "^2.5",
         "symfony/config": "^3.4 || ^4.2",

--- a/src/Entity/CategoryManager.php
+++ b/src/Entity/CategoryManager.php
@@ -230,7 +230,8 @@ class CategoryManager extends BaseEntityManager implements CategoryManagerInterf
 
     public function getBySlug(string $slug, $context = null, ?bool $enabled = true): ?CategoryInterface
     {
-        $queryBuilder = $this->getObjectManager()->createQueryBuilder()
+        $queryBuilder = $this->getRepository()
+            ->createQueryBuilder('c')
             ->select('c')
             ->andWhere('c.slug = :slug')->setParameter('slug', $slug);
 

--- a/src/Entity/CollectionManager.php
+++ b/src/Entity/CollectionManager.php
@@ -47,7 +47,8 @@ class CollectionManager extends BaseEntityManager implements CollectionManagerIn
 
     public function getBySlug(string $slug, $context = null, ?bool $enabled = true): ?CollectionInterface
     {
-        $queryBuilder = $this->getObjectManager()->createQueryBuilder()
+        $queryBuilder = $this->getRepository()
+            ->createQueryBuilder('c')
             ->select('c')
             ->andWhere('c.slug = :slug')->setParameter('slug', $slug);
 
@@ -63,7 +64,8 @@ class CollectionManager extends BaseEntityManager implements CollectionManagerIn
 
     public function getByContext($context, ?bool $enabled = true): array
     {
-        $queryBuilder = $this->getObjectManager()->createQueryBuilder()
+        $queryBuilder = $this->getRepository()
+            ->createQueryBuilder('c')
             ->select('c')
             ->andWhere('c.context = :context')->setParameter('context', $context);
 

--- a/src/Entity/TagManager.php
+++ b/src/Entity/TagManager.php
@@ -47,7 +47,8 @@ class TagManager extends BaseEntityManager implements TagManagerInterface
 
     public function getBySlug(string $slug, $context = null, ?bool $enabled = true): ?TagInterface
     {
-        $queryBuilder = $this->getObjectManager()->createQueryBuilder()
+        $queryBuilder = $this->getRepository()
+            ->createQueryBuilder('t')
             ->select('t')
             ->andWhere('t.slug = :slug')->setParameter('slug', $slug);
 
@@ -63,7 +64,8 @@ class TagManager extends BaseEntityManager implements TagManagerInterface
 
     public function getByContext($context, ?bool $enabled = true): array
     {
-        $queryBuilder = $this->getObjectManager()->createQueryBuilder()
+        $queryBuilder = $this->getRepository()
+            ->createQueryBuilder('t')
             ->select('t')
             ->andWhere('t.context = :context')->setParameter('context', $context);
 

--- a/tests/Entity/CategoryManagerTest.php
+++ b/tests/Entity/CategoryManagerTest.php
@@ -273,6 +273,25 @@ class CategoryManagerTest extends TestCase
         $this->assertContains($categoryBar, $categories[$contextBar->getId()]);
     }
 
+    public function testGetBySlug(): void
+    {
+        $self = $this;
+        $this
+            ->getCategoryManager(static function ($qb) use ($self): void {
+                $qb->expects($self->exactly(3))->method('andWhere')->withConsecutive(
+                    [$self->equalTo('c.slug = :slug')],
+                    [$self->equalTo('c.context = :context')],
+                    [$self->equalTo('c.enabled = :enabled')]
+                )->willReturn($qb);
+                $qb->expects($self->exactly(3))->method('setParameter')->withConsecutive(
+                    [$self->equalTo('slug'), $self->equalTo('theslug')],
+                    [$self->equalTo('context'), $self->equalTo('contextA')],
+                    [$self->equalTo('enabled'), $self->equalTo(false)]
+                )->willReturn($qb);
+            })
+            ->getBySlug('theslug', 'contextA', false);
+    }
+
     protected function getCategoryManager($qbCallback, $createQueryResult = null)
     {
         $em = $this->createEntityManagerMock($qbCallback, []);

--- a/tests/Entity/CategoryManagerTest.php
+++ b/tests/Entity/CategoryManagerTest.php
@@ -15,6 +15,7 @@ namespace Sonata\ClassificationBundle\Tests\Entity;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\AbstractQuery;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\ClassificationBundle\Entity\BaseCategory;
 use Sonata\ClassificationBundle\Entity\CategoryManager;
@@ -29,7 +30,7 @@ class CategoryManagerTest extends TestCase
     {
         $self = $this;
         $this
-            ->getCategoryManager(static function ($qb) use ($self): void {
+            ->getCategoryManager(static function (MockObject $qb) use ($self): void {
                 $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue([]));
                 $qb->expects($self->exactly(1))->method('andWhere')->withConsecutive(
                     [$self->equalTo('c.context = :context')]
@@ -43,7 +44,7 @@ class CategoryManagerTest extends TestCase
     {
         $self = $this;
         $this
-            ->getCategoryManager(static function ($qb) use ($self): void {
+            ->getCategoryManager(static function (MockObject $qb) use ($self): void {
                 $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue([]));
                 $qb->expects($self->exactly(2))->method('andWhere')->withConsecutive(
                     [$self->equalTo('c.context = :context')],
@@ -61,7 +62,7 @@ class CategoryManagerTest extends TestCase
     {
         $self = $this;
         $this
-            ->getCategoryManager(static function ($qb) use ($self): void {
+            ->getCategoryManager(static function (MockObject $qb) use ($self): void {
                 $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue([]));
                 $qb->expects($self->exactly(2))->method('andWhere')->withConsecutive(
                     [$self->equalTo('c.context = :context')],
@@ -101,7 +102,7 @@ class CategoryManagerTest extends TestCase
 
         $categories = [$categoryFoo, $categoryBar];
 
-        $categoryManager = $this->getCategoryManager(static function ($qb): void {
+        $categoryManager = $this->getCategoryManager(static function (MockObject $qb): void {
         }, $categories);
 
         $this->assertSame($categoryManager->getCategories($context), $categories);
@@ -131,7 +132,7 @@ class CategoryManagerTest extends TestCase
         $categoryBar->setParent($categoryFoo);
         $categoryBar->setEnabled(true);
 
-        $categoryManager = $this->getCategoryManager(static function ($qb): void {
+        $categoryManager = $this->getCategoryManager(static function (MockObject $qb): void {
         }, [$categoryFoo, $categoryBar]);
 
         $categoryFoo = $categoryManager->getRootCategoryWithChildren($categoryFoo);
@@ -154,7 +155,7 @@ class CategoryManagerTest extends TestCase
         $categoryFoo->setParent(null);
         $categoryFoo->setEnabled(true);
 
-        $categoryManager = $this->getCategoryManager(static function ($qb): void {
+        $categoryManager = $this->getCategoryManager(static function (MockObject $qb): void {
         }, [$categoryFoo]);
 
         $categoryBar = $categoryManager->getRootCategory($context);
@@ -185,7 +186,7 @@ class CategoryManagerTest extends TestCase
         $categoryBar->setParent($categoryFoo);
         $categoryBar->setEnabled(true);
 
-        $categoryManager = $this->getCategoryManager(static function ($qb): void {
+        $categoryManager = $this->getCategoryManager(static function (MockObject $qb): void {
         }, [$categoryFoo, $categoryBar]);
 
         $categories = $categoryManager->getRootCategoriesForContext($context);
@@ -223,7 +224,7 @@ class CategoryManagerTest extends TestCase
         $categoryBar->setParent(null);
         $categoryBar->setEnabled(true);
 
-        $categoryManager = $this->getCategoryManager(static function ($qb): void {
+        $categoryManager = $this->getCategoryManager(static function (MockObject $qb): void {
         }, [$categoryFoo, $categoryBar]);
 
         $categories = $categoryManager->getRootCategories(false);
@@ -263,7 +264,7 @@ class CategoryManagerTest extends TestCase
         $categoryBar->setParent(null);
         $categoryBar->setEnabled(true);
 
-        $categoryManager = $this->getCategoryManager(static function ($qb): void {
+        $categoryManager = $this->getCategoryManager(static function (MockObject $qb): void {
         }, [$categoryFoo, $categoryBar]);
 
         $categories = $categoryManager->getRootCategoriesSplitByContexts(false);
@@ -277,7 +278,7 @@ class CategoryManagerTest extends TestCase
     {
         $self = $this;
         $this
-            ->getCategoryManager(static function ($qb) use ($self): void {
+            ->getCategoryManager(static function (MockObject $qb) use ($self): void {
                 $qb->expects($self->exactly(3))->method('andWhere')->withConsecutive(
                     [$self->equalTo('c.slug = :slug')],
                     [$self->equalTo('c.context = :context')],
@@ -292,19 +293,19 @@ class CategoryManagerTest extends TestCase
             ->getBySlug('theslug', 'contextA', false);
     }
 
-    protected function getCategoryManager($qbCallback, $createQueryResult = null)
+    private function getCategoryManager($qbCallback, $createQueryResult = null): CategoryManager
     {
         $em = $this->createEntityManagerMock($qbCallback, []);
 
         if (null !== $createQueryResult) {
             $query = $this->createMock(AbstractQuery::class);
             $query->expects($this->once())->method('execute')->willReturn($createQueryResult);
-            $query->expects($this->any())->method('setParameter')->willReturn($query);
+            $query->method('setParameter')->willReturn($query);
             $em->expects($this->once())->method('createQuery')->willReturn($query);
         }
 
         $registry = $this->getMockForAbstractClass(ManagerRegistry::class);
-        $registry->expects($this->any())->method('getManagerForClass')->willReturn($em);
+        $registry->method('getManagerForClass')->willReturn($em);
 
         $contextManager = $this->createMock(ContextManagerInterface::class);
 

--- a/tests/Entity/CollectionManagerTest.php
+++ b/tests/Entity/CollectionManagerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\ClassificationBundle\Tests\Entity;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\AbstractQuery;
 use PHPUnit\Framework\TestCase;
 use Sonata\ClassificationBundle\Entity\BaseCollection;
 use Sonata\ClassificationBundle\Entity\CollectionManager;
@@ -63,9 +64,52 @@ class CollectionManagerTest extends TestCase
             ], 1);
     }
 
-    protected function getCollectionManager($qbCallback)
+    public function testGetBySlug(): void
+    {
+        $self = $this;
+        $this
+            ->getCollectionManager(static function ($qb) use ($self): void {
+                $qb->expects($self->exactly(3))->method('andWhere')->withConsecutive(
+                    [$self->equalTo('c.slug = :slug')],
+                    [$self->equalTo('c.context = :context')],
+                    [$self->equalTo('c.enabled = :enabled')]
+                )->willReturn($qb);
+                $qb->expects($self->exactly(3))->method('setParameter')->withConsecutive(
+                    [$self->equalTo('slug'), $self->equalTo('theslug')],
+                    [$self->equalTo('context'), $self->equalTo('contextA')],
+                    [$self->equalTo('enabled'), $self->equalTo(false)]
+                )->willReturn($qb);
+            })
+            ->getBySlug('theslug', 'contextA', false);
+    }
+
+    public function testGetByContext(): void
+    {
+        $self = $this;
+        $this
+            ->getCollectionManager(static function ($qb) use ($self): void {
+                $qb->expects($self->exactly(2))->method('andWhere')->withConsecutive(
+                    [$self->equalTo('c.context = :context')],
+                    [$self->equalTo('c.enabled = :enabled')]
+                )->willReturn($qb);
+                $qb->expects($self->exactly(2))->method('setParameter')->withConsecutive(
+                    [$self->equalTo('context'), $self->equalTo('contextA')],
+                    [$self->equalTo('enabled'), $self->equalTo(false)]
+                )->willReturn($qb);
+            }, [])
+            ->getByContext('contextA', false);
+    }
+
+    protected function getCollectionManager($qbCallback, $createQueryResult = null)
     {
         $em = $this->createEntityManagerMock($qbCallback, []);
+
+        if (null !== $createQueryResult) {
+            $query = $this->createMock(AbstractQuery::class);
+            $query->expects($this->once())->method('execute')->willReturn($createQueryResult);
+            $query->expects($this->any())->method('setParameter')->willReturn($query);
+            $em->expects($this->once())->method('createQuery')->willReturn($query);
+        }
 
         $registry = $this->getMockForAbstractClass(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->willReturn($em);

--- a/tests/Entity/ContextManagerTest.php
+++ b/tests/Entity/ContextManagerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\ClassificationBundle\Tests\Entity;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\ClassificationBundle\Entity\BaseContext;
 use Sonata\ClassificationBundle\Entity\ContextManager;
@@ -27,7 +28,7 @@ class ContextManagerTest extends TestCase
     {
         $self = $this;
         $this
-            ->getContextManager(static function ($qb) use ($self): void {
+            ->getContextManager(static function (MockObject $qb) use ($self): void {
                 $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue([]));
                 $qb->expects($self->never())->method('andWhere');
                 $qb->expects($self->once())->method('setParameters')->with([]);
@@ -39,7 +40,7 @@ class ContextManagerTest extends TestCase
     {
         $self = $this;
         $this
-            ->getContextManager(static function ($qb) use ($self): void {
+            ->getContextManager(static function (MockObject $qb) use ($self): void {
                 $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue([]));
                 $qb->expects($self->once())->method('andWhere')->with($self->equalTo('c.enabled = :enabled'));
                 $qb->expects($self->once())->method('setParameters')->with(['enabled' => true]);
@@ -53,7 +54,7 @@ class ContextManagerTest extends TestCase
     {
         $self = $this;
         $this
-            ->getContextManager(static function ($qb) use ($self): void {
+            ->getContextManager(static function (MockObject $qb) use ($self): void {
                 $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue([]));
                 $qb->expects($self->once())->method('andWhere')->with($self->equalTo('c.enabled = :enabled'));
                 $qb->expects($self->once())->method('setParameters')->with(['enabled' => false]);
@@ -63,12 +64,12 @@ class ContextManagerTest extends TestCase
             ], 1);
     }
 
-    protected function getContextManager($qbCallback)
+    private function getContextManager($qbCallback): ContextManager
     {
         $em = $this->createEntityManagerMock($qbCallback, []);
 
         $registry = $this->getMockForAbstractClass(ManagerRegistry::class);
-        $registry->expects($this->any())->method('getManagerForClass')->willReturn($em);
+        $registry->method('getManagerForClass')->willReturn($em);
 
         return new ContextManager(BaseContext::class, $registry);
     }

--- a/tests/Entity/TagManagerTest.php
+++ b/tests/Entity/TagManagerTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\ClassificationBundle\Tests\Entity;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\ORM\AbstractQuery;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\ClassificationBundle\Entity\BaseTag;
 use Sonata\ClassificationBundle\Entity\TagManager;
@@ -28,7 +28,7 @@ class TagManagerTest extends TestCase
     {
         $self = $this;
         $this
-            ->getTagManager(static function ($qb) use ($self): void {
+            ->getTagManager(static function (MockObject $qb) use ($self): void {
                 $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue([]));
                 $qb->expects($self->never())->method('andWhere');
                 $qb->expects($self->once())->method('setParameters')->with([]);
@@ -40,7 +40,7 @@ class TagManagerTest extends TestCase
     {
         $self = $this;
         $this
-            ->getTagManager(static function ($qb) use ($self): void {
+            ->getTagManager(static function (MockObject $qb) use ($self): void {
                 $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue([]));
                 $qb->expects($self->once())->method('andWhere')->with($self->equalTo('t.enabled = :enabled'));
                 $qb->expects($self->once())->method('setParameters')->with(['enabled' => true]);
@@ -54,7 +54,7 @@ class TagManagerTest extends TestCase
     {
         $self = $this;
         $this
-            ->getTagManager(static function ($qb) use ($self): void {
+            ->getTagManager(static function (MockObject $qb) use ($self): void {
                 $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue([]));
                 $qb->expects($self->once())->method('andWhere')->with($self->equalTo('t.enabled = :enabled'));
                 $qb->expects($self->once())->method('setParameters')->with(['enabled' => false]);
@@ -68,7 +68,7 @@ class TagManagerTest extends TestCase
     {
         $self = $this;
         $this
-            ->getTagManager(static function ($qb) use ($self): void {
+            ->getTagManager(static function (MockObject $qb) use ($self): void {
                 $qb->expects($self->exactly(3))->method('andWhere')->withConsecutive(
                     [$self->equalTo('t.slug = :slug')],
                     [$self->equalTo('t.context = :context')],
@@ -87,7 +87,7 @@ class TagManagerTest extends TestCase
     {
         $self = $this;
         $this
-            ->getTagManager(static function ($qb) use ($self): void {
+            ->getTagManager(static function (MockObject $qb) use ($self): void {
                 $qb->expects($self->exactly(2))->method('andWhere')->withConsecutive(
                     [$self->equalTo('t.context = :context')],
                     [$self->equalTo('t.enabled = :enabled')]
@@ -96,23 +96,16 @@ class TagManagerTest extends TestCase
                     [$self->equalTo('context'), $self->equalTo('contextA')],
                     [$self->equalTo('enabled'), $self->equalTo(false)]
                 )->willReturn($qb);
-            }, [])
+            })
             ->getByContext('contextA', false);
     }
 
-    protected function getTagManager($qbCallback, $createQueryResult = null)
+    private function getTagManager($qbCallback): TagManager
     {
         $em = $this->createEntityManagerMock($qbCallback, []);
 
-        if (null !== $createQueryResult) {
-            $query = $this->createMock(AbstractQuery::class);
-            $query->expects($this->once())->method('execute')->willReturn($createQueryResult);
-            $query->expects($this->any())->method('setParameter')->willReturn($query);
-            $em->expects($this->once())->method('createQuery')->willReturn($query);
-        }
-
         $registry = $this->getMockForAbstractClass(ManagerRegistry::class);
-        $registry->expects($this->any())->method('getManagerForClass')->willReturn($em);
+        $registry->method('getManagerForClass')->willReturn($em);
 
         return new TagManager(BaseTag::class, $registry);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

There was an lexer error in my previous PR:

```
[Syntax Error] line 0, col 9: Error: Expected Doctrine\ORM\Query\Lexer::T_FROM, got 'WHERE'
```

This results in an invalid query:

```
SELECT c WHERE c.slug = :slug AND c.context = :context AND c.enabled = :enabled
```

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes #517

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataClassificationBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix Lexer query error in managers
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
