### PR TITLE
Make SonataEasyExtends optional

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,14 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=======================
+
+### SonataEasyExtends is deprecated
+
+Registering `SonataEasyExtendsBundle` bundle is deprecated, it SHOULD NOT be registered.
+Register `SonataDoctrineBundle` bundle instead.
+
 UPGRADE FROM 3.1 to 3.2
 =======================
 
@@ -12,6 +20,6 @@ and should be done by overriding `getFormBuilder` instead.
 
 ### Tests
 
-All files under the ``Tests`` directory are now correctly handled as internal test classes. 
-You can't extend them anymore, because they are only loaded when running internal tests. 
+All files under the ``Tests`` directory are now correctly handled as internal test classes.
+You can't extend them anymore, because they are only loaded when running internal tests.
 More information can be found in the [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev).

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,9 @@
     ],
     "require": {
         "php": "^7.2",
-        "cocur/slugify": "^2.0 || ^3.0 || ^4.0",
+        "cocur/slugify": "^3.0 || ^4.0",
         "sonata-project/datagrid-bundle": "^2.3 || ^3.0",
-        "sonata-project/doctrine-extensions": "^1.6.0",
-        "sonata-project/easy-extends-bundle": "^2.5",
+        "sonata-project/doctrine-extensions": "^1.8",
         "sonata-project/form-extensions": "^0.1.1 || ^1.4",
         "symfony/config": "^4.4",
         "symfony/console": "^4.4",
@@ -39,18 +38,20 @@
     "conflict": {
         "friendsofsymfony/rest-bundle": "<2.1 || >=3.0",
         "jms/serializer": "<0.13",
-        "sonata-project/admin-bundle": "<3.59",
-        "sonata-project/block-bundle": "<3.14 || >=4.0",
+        "sonata-project/admin-bundle": "<3.68",
+        "sonata-project/block-bundle": "<3.19 || >=4.0",
         "sonata-project/core-bundle": "<3.20",
-        "sonata-project/doctrine-orm-admin-bundle": "<3.4",
-        "sonata-project/media-bundle": "<3.17 || >=4.0"
+        "sonata-project/doctrine-orm-admin-bundle": "<3.16",
+        "sonata-project/media-bundle": "<3.20 || >=4.0"
     },
     "require-dev": {
         "friendsofsymfony/rest-bundle": "^2.3",
         "jms/serializer-bundle": "^2.0 || ^3.0",
-        "sonata-project/admin-bundle": "^3.59",
-        "sonata-project/block-bundle": "^3.18",
-        "sonata-project/doctrine-orm-admin-bundle": "^3.4",
+        "matthiasnoback/symfony-config-test": "^4.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.0",
+        "sonata-project/admin-bundle": "^3.68",
+        "sonata-project/block-bundle": "^3.19",
+        "sonata-project/doctrine-orm-admin-bundle": "^3.16",
         "sonata-project/media-bundle": "^3.20",
         "symfony/phpunit-bridge": "^5.1"
     },

--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -10,26 +10,26 @@ Advanced Configuration
 
         sonata_classification:
             class:
-                tag:          Application\Sonata\ClassificationBundle\Entity\Tag
-                category:     Application\Sonata\ClassificationBundle\Entity\Category
-                collection:   Application\Sonata\ClassificationBundle\Entity\Collection
-                media:        Application\Sonata\MediaBundle\Entity\Media
-                context:      Application\Sonata\ClassificationBundle\Entity\Context
+                tag: App\Entity\SonataClassificationTag
+                category: App\Entity\SonataClassificationCategory
+                collection: App\Entity\SonataClassificationCollection
+                media: App\Entity\SonataMediaMedia
+                context: App\Entity\SonataClassificationContext
 
             admin:
                 tag:
-                    class:        Sonata\ClassificationBundle\Admin\TagAdmin
-                    controller:   SonataAdminBundle:CRUD
-                    translation:  SonataClassificationBundle
+                    class: Sonata\ClassificationBundle\Admin\TagAdmin
+                    controller: SonataAdminBundle:CRUD
+                    translation: SonataClassificationBundle
                 category:
-                    class:        Sonata\ClassificationBundle\Admin\CategoryAdmin
-                    controller:   SonataClassificationBundle:CategoryAdmin
-                    translation:  SonataClassificationBundle
+                    class: Sonata\ClassificationBundle\Admin\CategoryAdmin
+                    controller: SonataClassificationBundle:CategoryAdmin
+                    translation: SonataClassificationBundle
                 collection:
-                    class:        Sonata\ClassificationBundle\Admin\CollectionAdmin
-                    controller:   SonataAdminBundle:CRUD
-                    translation:  SonataClassificationBundle
+                    class: Sonata\ClassificationBundle\Admin\CollectionAdmin
+                    controller: SonataAdminBundle:CRUD
+                    translation: SonataClassificationBundle
                 context:
-                    class:        Sonata\ClassificationBundle\Admin\ContextAdmin
-                    controller:   SonataAdminBundle:CRUD
-                    translation:  SonataClassificationBundle
+                    class: Sonata\ClassificationBundle\Admin\ContextAdmin
+                    controller: SonataAdminBundle:CRUD
+                    translation: SonataClassificationBundle

--- a/src/Admin/ContextAwareAdmin.php
+++ b/src/Admin/ContextAwareAdmin.php
@@ -70,7 +70,7 @@ abstract class ContextAwareAdmin extends AbstractAdmin
             ]
         );
 
-        if ($this->getSubject()) {
+        if ($this->hasSubject()) {
             $parameters['context'] = $this->getSubject()->getContext() ? $this->getSubject()->getContext()->getId() : '';
 
             return $parameters;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -26,13 +26,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('sonata_classification');
-
-        // Keep compatibility with symfony/config < 4.2
-        if (!method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->root('sonata_classification');
-        } else {
-            $rootNode = $treeBuilder->getRootNode();
-        }
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/tests/Admin/Filter/CategoryFilterTest.php
+++ b/tests/Admin/Filter/CategoryFilterTest.php
@@ -15,19 +15,19 @@ namespace Sonata\ClassificationBundle\Tests\Admin\Filter;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\ClassificationBundle\Admin\Filter\CategoryFilter;
-use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
+use Sonata\ClassificationBundle\Entity\CategoryManager;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
 class CategoryFilterTest extends TestCase
 {
     /**
-     * @var MockObject&CategoryManagerInterface
+     * @var MockObject&CategoryManager
      */
     private $categoryManager;
 
     protected function setUp(): void
     {
-        $this->categoryManager = $this->createStub(CategoryManagerInterface::class);
+        $this->categoryManager = $this->createStub(CategoryManager::class);
     }
 
     public function testRenderSettings(): void

--- a/tests/Block/Service/AbstractCategoriesBlockServiceTest.php
+++ b/tests/Block/Service/AbstractCategoriesBlockServiceTest.php
@@ -15,12 +15,12 @@ namespace Sonata\ClassificationBundle\Tests\Block\Service;
 
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
-use Sonata\BlockBundle\Test\FakeTemplating;
 use Sonata\ClassificationBundle\Admin\CategoryAdmin;
 use Sonata\ClassificationBundle\Block\Service\AbstractCategoriesBlockService;
 use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
+use Twig\Environment;
 
 /**
  * @author Christian Gripp <mail@core23.de>
@@ -46,7 +46,7 @@ final class AbstractCategoriesBlockServiceTest extends BlockServiceTestCase
     {
         parent::setUp();
 
-        $this->templating = new FakeTemplating();
+        $this->twig = $this->createMock(Environment::class);
         $this->contextManager = $this->createMock(ContextManagerInterface::class);
         $this->categoryManager = $this->createMock(CategoryManagerInterface::class);
         $this->categoryAdmin = $this->createMock(CategoryAdmin::class);
@@ -55,7 +55,7 @@ final class AbstractCategoriesBlockServiceTest extends BlockServiceTestCase
     public function testDefaultSettings(): void
     {
         $blockService = $this->getMockForAbstractClass(AbstractCategoriesBlockService::class, [
-            'block.service', $this->templating, $this->contextManager, $this->categoryManager, $this->categoryAdmin,
+            $this->twig, $this->contextManager, $this->categoryManager, $this->categoryAdmin,
         ]);
         $blockContext = $this->getBlockContext($blockService);
 
@@ -94,7 +94,7 @@ final class AbstractCategoriesBlockServiceTest extends BlockServiceTestCase
             ->with($this->equalTo('categoryId'), $this->equalTo($category));
 
         $blockService = $this->getMockForAbstractClass(AbstractCategoriesBlockService::class, [
-            'block.service', $this->templating, $this->contextManager, $this->categoryManager, $this->categoryAdmin,
+            $this->twig, $this->contextManager, $this->categoryManager, $this->categoryAdmin,
         ]);
         $blockService->load($block);
     }
@@ -117,7 +117,7 @@ final class AbstractCategoriesBlockServiceTest extends BlockServiceTestCase
             ->with($this->equalTo('categoryId'), $this->equalTo(23));
 
         $blockService = $this->getMockForAbstractClass(AbstractCategoriesBlockService::class, [
-            'block.service', $this->templating, $this->contextManager, $this->categoryManager, $this->categoryAdmin,
+            $this->twig, $this->contextManager, $this->categoryManager, $this->categoryAdmin,
         ]);
         $blockService->prePersist($block);
     }
@@ -140,7 +140,7 @@ final class AbstractCategoriesBlockServiceTest extends BlockServiceTestCase
             ->with($this->equalTo('categoryId'), $this->equalTo(23));
 
         $blockService = $this->getMockForAbstractClass(AbstractCategoriesBlockService::class, [
-            'block.service', $this->templating, $this->contextManager, $this->categoryManager, $this->categoryAdmin,
+            $this->twig, $this->contextManager, $this->categoryManager, $this->categoryAdmin,
         ]);
         $blockService->preUpdate($block);
     }

--- a/tests/Block/Service/AbstractCollectionsBlockServiceTest.php
+++ b/tests/Block/Service/AbstractCollectionsBlockServiceTest.php
@@ -15,12 +15,12 @@ namespace Sonata\ClassificationBundle\Tests\Block\Service;
 
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
-use Sonata\BlockBundle\Test\FakeTemplating;
 use Sonata\ClassificationBundle\Admin\CollectionAdmin;
 use Sonata\ClassificationBundle\Block\Service\AbstractCollectionsBlockService;
 use Sonata\ClassificationBundle\Model\CollectionInterface;
 use Sonata\ClassificationBundle\Model\CollectionManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
+use Twig\Environment;
 
 /**
  * @author Christian Gripp <mail@core23.de>
@@ -46,7 +46,7 @@ final class AbstractCollectionsBlockServiceTest extends BlockServiceTestCase
     {
         parent::setUp();
 
-        $this->templating = new FakeTemplating();
+        $this->twig = $this->createMock(Environment::class);
         $this->contextManager = $this->createMock(ContextManagerInterface::class);
         $this->collectionManager = $this->createMock(CollectionManagerInterface::class);
         $this->collectionAdmin = $this->createMock(CollectionAdmin::class);
@@ -55,7 +55,7 @@ final class AbstractCollectionsBlockServiceTest extends BlockServiceTestCase
     public function testDefaultSettings(): void
     {
         $blockService = $this->getMockForAbstractClass(AbstractCollectionsBlockService::class, [
-            'block.service', $this->templating, $this->contextManager, $this->collectionManager, $this->collectionAdmin,
+            $this->twig, $this->contextManager, $this->collectionManager, $this->collectionAdmin,
         ]);
         $blockContext = $this->getBlockContext($blockService);
 
@@ -94,7 +94,7 @@ final class AbstractCollectionsBlockServiceTest extends BlockServiceTestCase
             ->with($this->equalTo('collectionId'), $this->equalTo($collection));
 
         $blockService = $this->getMockForAbstractClass(AbstractCollectionsBlockService::class, [
-            'block.service', $this->templating, $this->contextManager, $this->collectionManager, $this->collectionAdmin,
+            $this->twig, $this->contextManager, $this->collectionManager, $this->collectionAdmin,
         ]);
         $blockService->load($block);
     }
@@ -117,7 +117,7 @@ final class AbstractCollectionsBlockServiceTest extends BlockServiceTestCase
             ->with($this->equalTo('collectionId'), $this->equalTo(23));
 
         $blockService = $this->getMockForAbstractClass(AbstractCollectionsBlockService::class, [
-            'block.service', $this->templating, $this->contextManager, $this->collectionManager, $this->collectionAdmin,
+            $this->twig, $this->contextManager, $this->collectionManager, $this->collectionAdmin,
         ]);
         $blockService->prePersist($block);
     }
@@ -140,7 +140,7 @@ final class AbstractCollectionsBlockServiceTest extends BlockServiceTestCase
             ->with($this->equalTo('collectionId'), $this->equalTo(23));
 
         $blockService = $this->getMockForAbstractClass(AbstractCollectionsBlockService::class, [
-            'block.service', $this->templating, $this->contextManager, $this->collectionManager, $this->collectionAdmin,
+            $this->twig, $this->contextManager, $this->collectionManager, $this->collectionAdmin,
         ]);
         $blockService->preUpdate($block);
     }

--- a/tests/Block/Service/AbstractTagsBlockServiceTest.php
+++ b/tests/Block/Service/AbstractTagsBlockServiceTest.php
@@ -15,12 +15,12 @@ namespace Sonata\ClassificationBundle\Tests\Block\Service;
 
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
-use Sonata\BlockBundle\Test\FakeTemplating;
 use Sonata\ClassificationBundle\Admin\TagAdmin;
 use Sonata\ClassificationBundle\Block\Service\AbstractTagsBlockService;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 use Sonata\ClassificationBundle\Model\TagInterface;
 use Sonata\ClassificationBundle\Model\TagManagerInterface;
+use Twig\Environment;
 
 /**
  * @author Christian Gripp <mail@core23.de>
@@ -46,7 +46,7 @@ final class AbstractTagsBlockServiceTest extends BlockServiceTestCase
     {
         parent::setUp();
 
-        $this->templating = new FakeTemplating();
+        $this->twig = $this->createMock(Environment::class);
         $this->contextManager = $this->createMock(ContextManagerInterface::class);
         $this->tagManager = $this->createMock(TagManagerInterface::class);
         $this->tagAdmin = $this->createMock(TagAdmin::class);
@@ -55,7 +55,7 @@ final class AbstractTagsBlockServiceTest extends BlockServiceTestCase
     public function testDefaultSettings(): void
     {
         $blockService = $this->getMockForAbstractClass(AbstractTagsBlockService::class, [
-            'block.service', $this->templating, $this->contextManager, $this->tagManager, $this->tagAdmin,
+            $this->twig, $this->contextManager, $this->tagManager, $this->tagAdmin,
         ]);
         $blockContext = $this->getBlockContext($blockService);
 
@@ -94,7 +94,7 @@ final class AbstractTagsBlockServiceTest extends BlockServiceTestCase
             ->with($this->equalTo('tagId'), $this->equalTo($tag));
 
         $blockService = $this->getMockForAbstractClass(AbstractTagsBlockService::class, [
-            'block.service', $this->templating, $this->contextManager, $this->tagManager, $this->tagAdmin,
+            $this->twig, $this->contextManager, $this->tagManager, $this->tagAdmin,
         ]);
         $blockService->load($block);
     }
@@ -117,7 +117,7 @@ final class AbstractTagsBlockServiceTest extends BlockServiceTestCase
             ->with($this->equalTo('tagId'), $this->equalTo(23));
 
         $blockService = $this->getMockForAbstractClass(AbstractTagsBlockService::class, [
-            'block.service', $this->templating, $this->contextManager, $this->tagManager, $this->tagAdmin,
+            $this->twig, $this->contextManager, $this->tagManager, $this->tagAdmin,
         ]);
         $blockService->prePersist($block);
     }
@@ -140,7 +140,7 @@ final class AbstractTagsBlockServiceTest extends BlockServiceTestCase
             ->with($this->equalTo('tagId'), $this->equalTo(23));
 
         $blockService = $this->getMockForAbstractClass(AbstractTagsBlockService::class, [
-            'block.service', $this->templating, $this->contextManager, $this->tagManager, $this->tagAdmin,
+            $this->twig, $this->contextManager, $this->tagManager, $this->tagAdmin,
         ]);
         $blockService->preUpdate($block);
     }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Tests\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionConfigurationTestCase;
+use Sonata\ClassificationBundle\Admin\CategoryAdmin;
+use Sonata\ClassificationBundle\Admin\CollectionAdmin;
+use Sonata\ClassificationBundle\Admin\ContextAdmin;
+use Sonata\ClassificationBundle\Admin\TagAdmin;
+use Sonata\ClassificationBundle\DependencyInjection\Configuration;
+use Sonata\ClassificationBundle\DependencyInjection\SonataClassificationExtension;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+
+final class ConfigurationTest extends AbstractExtensionConfigurationTestCase
+{
+    public function testDefault(): void
+    {
+        $this->assertProcessedConfigurationEquals([
+            'class' => [
+                'category' => 'Application\Sonata\ClassificationBundle\Entity\Category',
+                'tag' => 'Application\Sonata\ClassificationBundle\Entity\Tag',
+                'media' => null,
+                'collection' => 'Application\Sonata\ClassificationBundle\Entity\Collection',
+                'context' => 'Application\Sonata\ClassificationBundle\Entity\Context',
+            ],
+            'admin' => [
+                'category' => [
+                    'class' => CategoryAdmin::class,
+                    'controller' => 'SonataClassificationBundle:CategoryAdmin',
+                    'translation' => 'SonataClassificationBundle',
+                ],
+                'tag' => [
+                    'class' => TagAdmin::class,
+                    'controller' => 'SonataAdminBundle:CRUD',
+                    'translation' => 'SonataClassificationBundle',
+                ],
+                'collection' => [
+                    'class' => CollectionAdmin::class,
+                    'controller' => 'SonataAdminBundle:CRUD',
+                    'translation' => 'SonataClassificationBundle',
+                ],
+                'context' => [
+                    'class' => ContextAdmin::class,
+                    'controller' => 'SonataAdminBundle:CRUD',
+                    'translation' => 'SonataClassificationBundle',
+                ],
+            ],
+        ], [
+            __DIR__.'/../Fixtures/configuration.yaml',
+        ]);
+    }
+
+    protected function getContainerExtension(): ExtensionInterface
+    {
+        return new SonataClassificationExtension();
+    }
+
+    protected function getConfiguration(): ConfigurationInterface
+    {
+        return new Configuration();
+    }
+}

--- a/tests/DependencyInjection/SonataClassificationExtensionTest.php
+++ b/tests/DependencyInjection/SonataClassificationExtensionTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Tests\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sonata\ClassificationBundle\Admin\CategoryAdmin;
+use Sonata\ClassificationBundle\Admin\CollectionAdmin;
+use Sonata\ClassificationBundle\Admin\ContextAdmin;
+use Sonata\ClassificationBundle\Admin\Filter\CategoryFilter;
+use Sonata\ClassificationBundle\Admin\Filter\CollectionFilter;
+use Sonata\ClassificationBundle\Admin\TagAdmin;
+use Sonata\ClassificationBundle\Command\FixContextCommand;
+use Sonata\ClassificationBundle\Controller\Api\CategoryController;
+use Sonata\ClassificationBundle\Controller\Api\CollectionController;
+use Sonata\ClassificationBundle\Controller\Api\ContextController;
+use Sonata\ClassificationBundle\Controller\Api\TagController;
+use Sonata\ClassificationBundle\DependencyInjection\SonataClassificationExtension;
+use Sonata\ClassificationBundle\Entity\CategoryManager;
+use Sonata\ClassificationBundle\Entity\CollectionManager;
+use Sonata\ClassificationBundle\Entity\ContextManager;
+use Sonata\ClassificationBundle\Entity\TagManager;
+use Sonata\ClassificationBundle\Form\Type\ApiCategoryType;
+use Sonata\ClassificationBundle\Form\Type\ApiCollectionType;
+use Sonata\ClassificationBundle\Form\Type\ApiContextType;
+use Sonata\ClassificationBundle\Form\Type\ApiTagType;
+use Sonata\ClassificationBundle\Form\Type\CategorySelectorType;
+use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
+use Sonata\ClassificationBundle\Model\CollectionManagerInterface;
+use Sonata\ClassificationBundle\Model\ContextManagerInterface;
+use Sonata\ClassificationBundle\Model\TagManagerInterface;
+use Sonata\ClassificationBundle\Serializer\CategorySerializerHandler;
+use Sonata\ClassificationBundle\Serializer\CollectionSerializerHandler;
+use Sonata\ClassificationBundle\Serializer\ContextSerializerHandler;
+use Sonata\ClassificationBundle\Serializer\TagSerializerHandler;
+
+final class SonataClassificationExtensionTest extends AbstractExtensionTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->container->setParameter('kernel.bundles', [
+            'SonataDoctrineBundle' => true,
+            'SonataAdminBundle' => true,
+            'FOSRestBundle' => true,
+            'NelmioApiDocBundle' => true,
+        ]);
+    }
+
+    public function testLoadDefault(): void
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasService('sonata.classification.admin.category', CategoryAdmin::class);
+        $this->assertContainerBuilderHasService('sonata.classification.admin.tag', TagAdmin::class);
+        $this->assertContainerBuilderHasService('sonata.classification.admin.collection', CollectionAdmin::class);
+        $this->assertContainerBuilderHasService('sonata.classification.admin.context', ContextAdmin::class);
+        $this->assertContainerBuilderHasService(CategoryFilter::class);
+        $this->assertContainerBuilderHasService(CollectionFilter::class);
+        $this->assertContainerBuilderHasService('sonata.classification.controller.api.category', CategoryController::class);
+        $this->assertContainerBuilderHasService('sonata.classification.controller.api.collection', CollectionController::class);
+        $this->assertContainerBuilderHasService('sonata.classification.controller.api.tag', TagController::class);
+        $this->assertContainerBuilderHasService('sonata.classification.controller.api.context', ContextController::class);
+        $this->assertContainerBuilderHasService('sonata.classification.api.form.type.category', ApiCategoryType::class);
+        $this->assertContainerBuilderHasService('sonata.classification.api.form.type.collection', ApiCollectionType::class);
+        $this->assertContainerBuilderHasService('sonata.classification.api.form.type.tag', ApiTagType::class);
+        $this->assertContainerBuilderHasService('sonata.classification.api.form.type.context', ApiContextType::class);
+        $this->assertContainerBuilderHasService(FixContextCommand::class);
+        $this->assertContainerBuilderHasService('sonata.classification.form.type.category_selector', CategorySelectorType::class);
+        $this->assertContainerBuilderHasService('sonata.classification.manager.category', CategoryManager::class);
+        $this->assertContainerBuilderHasService('sonata.classification.manager.tag', TagManager::class);
+        $this->assertContainerBuilderHasService('sonata.classification.manager.collection', CollectionManager::class);
+        $this->assertContainerBuilderHasService('sonata.classification.manager.context', ContextManager::class);
+        $this->assertContainerBuilderHasService(CategoryManagerInterface::class);
+        $this->assertContainerBuilderHasService(TagManagerInterface::class);
+        $this->assertContainerBuilderHasService(CollectionManagerInterface::class);
+        $this->assertContainerBuilderHasService(ContextManagerInterface::class);
+        $this->assertContainerBuilderHasService('sonata.classification.serializer.handler.category', CategorySerializerHandler::class);
+        $this->assertContainerBuilderHasService('sonata.classification.serializer.handler.collection', CollectionSerializerHandler::class);
+        $this->assertContainerBuilderHasService('sonata.classification.serializer.handler.tag', TagSerializerHandler::class);
+        $this->assertContainerBuilderHasService('sonata.classification.serializer.handler.context', ContextSerializerHandler::class);
+
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.category.entity', 'Application\Sonata\ClassificationBundle\Entity\Category');
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.category.class', CategoryAdmin::class);
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.category.controller', 'SonataClassificationBundle:CategoryAdmin');
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.category.translation_domain', 'SonataClassificationBundle');
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.tag.entity', 'Application\Sonata\ClassificationBundle\Entity\Tag');
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.tag.class', TagAdmin::class);
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.tag.controller', 'SonataAdminBundle:CRUD');
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.tag.translation_domain', 'SonataClassificationBundle');
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.collection.entity', 'Application\Sonata\ClassificationBundle\Entity\Collection');
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.collection.class', CollectionAdmin::class);
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.collection.controller', 'SonataAdminBundle:CRUD');
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.collection.translation_domain', 'SonataClassificationBundle');
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.context.entity', 'Application\Sonata\ClassificationBundle\Entity\Context');
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.context.class', ContextAdmin::class);
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.context.controller', 'SonataAdminBundle:CRUD');
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.context.translation_domain', 'SonataClassificationBundle');
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.groupname', 'sonata_classification');
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.groupicon', "<i class='fa fa-tags'></i>");
+
+        $this->assertContainerBuilderHasParameter('sonata.classification.manager.category.class', CategoryManager::class);
+        $this->assertContainerBuilderHasParameter('sonata.classification.manager.tag.class', TagManager::class);
+        $this->assertContainerBuilderHasParameter('sonata.classification.manager.collection.class', CollectionManager::class);
+        $this->assertContainerBuilderHasParameter('sonata.classification.manager.context.class', ContextManager::class);
+    }
+
+    protected function getContainerExtensions(): array
+    {
+        return [
+            new SonataClassificationExtension(),
+        ];
+    }
+}

--- a/tests/Resources/XliffTest.php
+++ b/tests/Resources/XliffTest.php
@@ -36,6 +36,7 @@ class XliffTest extends TestCase
 
     /**
      * @dataProvider getXliffPaths
+     * @doesNotPerformAssertions
      */
     public function testXliff($path)
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataArticleBundle/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

Part of: https://github.com/sonata-project/dev-kit/issues/750
Closes: #502 

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

SonataEasyExtends is deprecated but it is used on many bundles, this makes it optional. This change is BC because if the user does not change anything it will continue using the deprecated code but with a message.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataArticleBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- SonataEasyExtendsBundle is now optional, using SonataDoctrineBundle is preferred
### Deprecated
- Using SonataEasyExtendsBundle to add Doctrine mapping information
```

## To do

- [x] Update the documentation;
- [x] Add an upgrade note.
