### PR TITLE
Bump Symfony < 4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,13 @@
         "sonata-project/doctrine-extensions": "^1.6.0",
         "sonata-project/easy-extends-bundle": "^2.5",
         "sonata-project/form-extensions": "^0.1.1 || ^1.4",
-        "symfony/config": "^4.3",
-        "symfony/console": "^4.3",
-        "symfony/dependency-injection": "^4.3",
-        "symfony/form": "^4.3",
-        "symfony/http-foundation": "^4.3",
-        "symfony/http-kernel": "^4.3",
-        "symfony/options-resolver": "^4.3",
+        "symfony/config": "^4.4",
+        "symfony/console": "^4.4",
+        "symfony/dependency-injection": "^4.4",
+        "symfony/form": "^4.4",
+        "symfony/http-foundation": "^4.4",
+        "symfony/http-kernel": "^4.4",
+        "symfony/options-resolver": "^4.4",
         "twig/twig": "^2.12.1"
     },
     "conflict": {
@@ -52,7 +52,7 @@
         "sonata-project/block-bundle": "^3.18",
         "sonata-project/doctrine-orm-admin-bundle": "^3.4",
         "sonata-project/media-bundle": "^3.20",
-        "symfony/phpunit-bridge": "^5.0"
+        "symfony/phpunit-bridge": "^5.1"
     },
     "suggest": {
         "sonata-project/block-bundle": "For rendering dynamic list blocks on a page.",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Some bundles like: NotificationBundle, DoctrineORMAdminBundle, PageBundle, SeoBundle, UserBundle using Symfony v4.4. To avoid situation like [here](https://github.com/sonata-project/SonataPageBundle/issues/1168#issuecomment-655587405) some bundles like this must bump Symfony < 4.4 too.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Support for Symfony < 4.4
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
