### PR TITLE
Add missing import for PHPDoc in block services

### DIFF
--- a/src/Block/Service/AbstractCategoriesBlockService.php
+++ b/src/Block/Service/AbstractCategoriesBlockService.php
@@ -27,6 +27,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Twig\Environment;
 
 /**
  * @author Christian Gripp <mail@core23.de>

--- a/src/Block/Service/AbstractCollectionsBlockService.php
+++ b/src/Block/Service/AbstractCollectionsBlockService.php
@@ -27,6 +27,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Twig\Environment;
 
 /**
  * @author Christian Gripp <mail@core23.de>

--- a/src/Block/Service/AbstractTagsBlockService.php
+++ b/src/Block/Service/AbstractTagsBlockService.php
@@ -27,6 +27,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Twig\Environment;
 
 /**
  * @author Christian Gripp <mail@core23.de>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a pedantic change, because it only affects PHPDoc.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->