### PR TITLE
Make admin dependency optional for block rendering

### DIFF
--- a/src/Block/Service/AbstractCategoriesBlockService.php
+++ b/src/Block/Service/AbstractCategoriesBlockService.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\ClassificationBundle\Block\Service;
 
+use BadMethodCallException;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
@@ -40,7 +41,7 @@ abstract class AbstractCategoriesBlockService extends AbstractClassificationBloc
     private $categoryManager;
 
     /**
-     * @var AdminInterface
+     * @var AdminInterface|null
      */
     private $categoryAdmin;
 
@@ -48,7 +49,7 @@ abstract class AbstractCategoriesBlockService extends AbstractClassificationBloc
      * @param string|Environment                               $twigOrDeprecatedName
      * @param EngineInterface|ContextManagerInterface          $contextManagerOrDeprecatedTemplating
      * @param ContextManagerInterface|CategoryManagerInterface $categoryManagerOrDeprecatedContextManager
-     * @param CategoryManagerInterface|AdminInterface          $categoryAdminOrDeprecatedCategoryManager
+     * @param CategoryManagerInterface|AdminInterface|null     $categoryAdminOrDeprecatedCategoryManager
      * @param AdminInterface|null                              $deprecatedCategoryAdmin
      */
     public function __construct(
@@ -95,6 +96,10 @@ abstract class AbstractCategoriesBlockService extends AbstractClassificationBloc
 
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
+        if (null === $this->categoryAdmin) {
+            throw new BadMethodCallException('You need the sonata-project/admin-bundle library to edit this block.');
+        }
+
         $adminField = $this->getFormAdminType($formMapper, $this->categoryAdmin, 'categoryId', 'category', [
             'label' => 'form.label_category',
         ], [

--- a/src/Block/Service/AbstractCollectionsBlockService.php
+++ b/src/Block/Service/AbstractCollectionsBlockService.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\ClassificationBundle\Block\Service;
 
+use BadMethodCallException;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
@@ -40,7 +41,7 @@ abstract class AbstractCollectionsBlockService extends AbstractClassificationBlo
     private $collectionManager;
 
     /**
-     * @var AdminInterface
+     * @var AdminInterface|null
      */
     private $collectionAdmin;
 
@@ -50,7 +51,7 @@ abstract class AbstractCollectionsBlockService extends AbstractClassificationBlo
      * @param string|Environment                                 $twigOrDeprecatedName
      * @param EngineInterface|ContextManagerInterface            $contextManagerOrDeprecatedTemplating
      * @param ContextManagerInterface|CollectionManagerInterface $collectionManagerOrDeprecatedContextManager
-     * @param CollectionManagerInterface|AdminInterface          $collectionAdminOrDeprecatedCollectionManager
+     * @param CollectionManagerInterface|AdminInterface|null     $collectionAdminOrDeprecatedCollectionManager
      * @param AdminInterface|null                                $deprecatedCollectionAdmin
      */
     public function __construct(
@@ -100,6 +101,10 @@ abstract class AbstractCollectionsBlockService extends AbstractClassificationBlo
 
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
+        if (null === $this->collectionAdmin) {
+            throw new BadMethodCallException('You need the sonata-project/admin-bundle library to edit this block.');
+        }
+
         $adminField = $this->getFormAdminType($formMapper, $this->collectionAdmin, 'collectionId', 'collection', [
             'label' => 'form.label_collection',
         ], [

--- a/src/Block/Service/AbstractTagsBlockService.php
+++ b/src/Block/Service/AbstractTagsBlockService.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\ClassificationBundle\Block\Service;
 
+use BadMethodCallException;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
@@ -40,7 +41,7 @@ abstract class AbstractTagsBlockService extends AbstractClassificationBlockServi
     private $tagManager;
 
     /**
-     * @var AdminInterface
+     * @var AdminInterface|null
      */
     private $tagAdmin;
 
@@ -48,7 +49,7 @@ abstract class AbstractTagsBlockService extends AbstractClassificationBlockServi
      * @param string|Environment                           $twigOrDeprecatedName
      * @param EngineInterface|ContextManagerInterface      $contextManagerOrDeprecatedTemplating
      * @param ContextManagerInterface|TagManagerInterface| $tagManagerOrDeprecatedContextManager
-     * @param TagManagerInterface|AdminInterface           $tagAdminOrDeprecatedTagManager
+     * @param TagManagerInterface|AdminInterface|null      $tagAdminOrDeprecatedTagManager
      * @param AdminInterface|null                          $deprecatedTagAdmin
      */
     public function __construct(
@@ -98,6 +99,10 @@ abstract class AbstractTagsBlockService extends AbstractClassificationBlockServi
 
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
+        if (null === $this->tagAdmin) {
+            throw new BadMethodCallException('You need the sonata-project/admin-bundle library to edit this block.');
+        }
+
         $adminField = $this->getFormAdminType($formMapper, $this->tagAdmin, 'tagId', 'tag', [
             'label' => 'form.label_tag',
         ], [


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

The admin dependency is optional for this bundle, however the blocks still depend on an admin. 

This PR makes the admin dependency optional, if you just want to use block rendering  (`BlockInterface::execute`) without editing it.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataClassificationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Make admin dependency optional for block rendering
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
