### PR TITLE
Fix loading CategoryFilter items

### DIFF
--- a/src/Admin/Filter/CategoryFilter.php
+++ b/src/Admin/Filter/CategoryFilter.php
@@ -96,7 +96,7 @@ final class CategoryFilter extends Filter
         if (null === $context) {
             $categories = $this->categoryManager->getAllRootCategories();
         } else {
-            $categories = $this->categoryManager->getRootCategoriesForContext($context);
+            $categories = $this->categoryManager->getCategories($context);
         }
 
         $choices = [];

--- a/src/Model/CategoryManagerInterface.php
+++ b/src/Model/CategoryManagerInterface.php
@@ -20,7 +20,7 @@ use Sonata\Doctrine\Model\PageableManagerInterface;
 /**
  * @method PagerInterface         getRootCategoriesPager(int $page = 1, int $limit = 25, array $criteria = [])
  * @method PagerInterface         getSubCategoriesPager(int $categoryId, int $page = 1, int $limit = 25, array $criteria = [])
- * @method CategoryInterface[]    getRootCategoriesForContext(ContextInterface|string|null $context)
+ * @method CategoryInterface[]    getRootCategoriesForContext(ContextInterface|null $context)
  * @method CategoryInterface[]    getAllRootCategories(bool $loadChildren = true)
  * @method CategoryInterface[]    getRootCategoriesSplitByContexts(bool $loadChildren = true)
  * @method CategoryInterface[]    getCategories(ContextInterface|string|null $context)

--- a/tests/Admin/Filter/CategoryFilterTest.php
+++ b/tests/Admin/Filter/CategoryFilterTest.php
@@ -16,6 +16,7 @@ namespace Sonata\ClassificationBundle\Tests\Admin\Filter;
 use PHPUnit\Framework\TestCase;
 use Sonata\ClassificationBundle\Admin\Filter\CategoryFilter;
 use Sonata\ClassificationBundle\Entity\CategoryManager;
+use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
 class CategoryFilterTest extends TestCase
@@ -32,7 +33,9 @@ class CategoryFilterTest extends TestCase
 
     public function testRenderSettings(): void
     {
-        $this->categoryManager->method('getAllRootCategories')->willReturn([]);
+        $this->categoryManager->method('getAllRootCategories')->willReturn([
+            $category = $this->createCategoryMock(),
+        ]);
 
         $filter = new CategoryFilter($this->categoryManager);
         $filter->initialize('field_name', [
@@ -41,6 +44,37 @@ class CategoryFilterTest extends TestCase
         $options = $filter->getRenderSettings()[1];
 
         $this->assertSame(ChoiceType::class, $options['field_type']);
-        $this->assertSame([], $options['field_options']['choices']);
+        $this->assertSame([
+            $category,
+        ], $options['field_options']['choices']);
+    }
+
+    public function testRenderSettingsWithContext(): void
+    {
+        $this->categoryManager->method('getCategories')->willReturn([
+            $category = $this->createCategoryMock(),
+        ]);
+
+        $filter = new CategoryFilter($this->categoryManager);
+        $filter->initialize('field_name', [
+            'field_options' => [
+                'class' => 'FooBar',
+                'context' => 'foo',
+            ],
+        ]);
+        $options = $filter->getRenderSettings()[1];
+
+        $this->assertSame(ChoiceType::class, $options['field_type']);
+        $this->assertSame([
+            $category,
+        ], $options['field_options']['choices']);
+    }
+
+    private function createCategoryMock(): CategoryInterface
+    {
+        $category = $this->createMock(CategoryInterface::class);
+        $category->method('getId')->willReturn(1);
+
+        return $category;
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
The filter was calling the wrong method. The called method does allow passing a string value as a parameter.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataClassificationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix loading CategoryFilter items
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
