### PR TITLE
Update Swagger definition in order to be compatible with string ident…

### DIFF
--- a/src/Controller/Api/CategoryController.php
+++ b/src/Controller/Api/CategoryController.php
@@ -81,7 +81,7 @@ class CategoryController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Category identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Category identifier"}
      *  },
      *  output={"class"="Sonata\ClassificationBundle\Model\Category", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -92,7 +92,7 @@ class CategoryController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param mixed $id Category identifier
+     * @param string $id Category identifier
      *
      * @return CategoryInterface
      */
@@ -130,7 +130,7 @@ class CategoryController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Category identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Category identifier"}
      *  },
      *  input={"class"="sonata_classification_api_form_category", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="Sonata\ClassificationBundle\Model\Category", "groups"={"sonata_api_read"}},
@@ -141,7 +141,7 @@ class CategoryController
      *  }
      * )
      *
-     * @param int     $id      Category identifier
+     * @param string  $id      Category identifier
      * @param Request $request Symfony request
      *
      * @throws NotFoundHttpException
@@ -158,7 +158,7 @@ class CategoryController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Category identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Category identifier"}
      *  },
      *  statusCodes={
      *      200="Returned when category is successfully deleted",
@@ -167,7 +167,7 @@ class CategoryController
      *  }
      * )
      *
-     * @param int $id Category identifier
+     * @param string $id Category identifier
      *
      * @throws NotFoundHttpException
      *
@@ -205,7 +205,7 @@ class CategoryController
     /**
      * Retrieves category with id $id or throws an exception if it doesn't exist.
      *
-     * @param int $id Category identifier
+     * @param string $id Category identifier
      *
      * @throws NotFoundHttpException
      *
@@ -225,8 +225,8 @@ class CategoryController
     /**
      * Write a category, this method is used by both POST and PUT action methods.
      *
-     * @param Request  $request Symfony request
-     * @param int|null $id      category identifier
+     * @param Request     $request Symfony request
+     * @param string|null $id      category identifier
      *
      * @return Rest\View|FormInterface
      */

--- a/src/Controller/Api/CollectionController.php
+++ b/src/Controller/Api/CollectionController.php
@@ -80,7 +80,7 @@ class CollectionController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Collection identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Collection identifier"}
      *  },
      *  output={"class"="Sonata\ClassificationBundle\Model\Collection", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -91,7 +91,7 @@ class CollectionController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param mixed $id Collection identifier
+     * @param string $id Collection identifier
      *
      * @return CollectionInterface
      */
@@ -129,7 +129,7 @@ class CollectionController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Collection identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Collection identifier"}
      *  },
      *  input={"class"="sonata_classification_api_form_collection", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="Sonata\ClassificationBundle\Model\Collection", "groups"={"sonata_api_read"}},
@@ -140,7 +140,7 @@ class CollectionController
      *  }
      * )
      *
-     * @param int     $id      Collection identifier
+     * @param string  $id      Collection identifier
      * @param Request $request Symfony request
      *
      * @throws NotFoundHttpException
@@ -157,7 +157,7 @@ class CollectionController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Collection identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Collection identifier"}
      *  },
      *  statusCodes={
      *      200="Returned when collection is successfully deleted",
@@ -166,7 +166,7 @@ class CollectionController
      *  }
      * )
      *
-     * @param int $id Collection identifier
+     * @param string $id Collection identifier
      *
      * @throws NotFoundHttpException
      *
@@ -204,7 +204,7 @@ class CollectionController
     /**
      * Retrieves collection with id $id or throws an exception if it doesn't exist.
      *
-     * @param int $id Collection identifier
+     * @param string $id Collection identifier
      *
      * @throws NotFoundHttpException
      *
@@ -224,8 +224,8 @@ class CollectionController
     /**
      * Write a collection, this method is used by both POST and PUT action methods.
      *
-     * @param Request  $request Symfony request
-     * @param int|null $id      Collection identifier
+     * @param Request     $request Symfony request
+     * @param string|null $id      Collection identifier
      *
      * @return Rest\View|FormInterface
      */

--- a/src/Controller/Api/ContextController.php
+++ b/src/Controller/Api/ContextController.php
@@ -80,7 +80,7 @@ class ContextController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Context identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Context identifier"}
      *  },
      *  output={"class"="Sonata\ClassificationBundle\Model\Context", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -91,7 +91,7 @@ class ContextController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param mixed $id Context identifier
+     * @param string $id Context identifier
      *
      * @return ContextInterface
      */
@@ -129,7 +129,7 @@ class ContextController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Context identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Context identifier"}
      *  },
      *  input={"class"="sonata_classification_api_form_context", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="Sonata\ClassificationBundle\Model\Context", "groups"={"sonata_api_read"}},
@@ -140,7 +140,7 @@ class ContextController
      *  }
      * )
      *
-     * @param int     $id      Context identifier
+     * @param string  $id      Context identifier
      * @param Request $request Symfony request
      *
      * @throws NotFoundHttpException
@@ -157,7 +157,7 @@ class ContextController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Context identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Context identifier"}
      *  },
      *  statusCodes={
      *      200="Returned when context is successfully deleted",
@@ -166,7 +166,7 @@ class ContextController
      *  }
      * )
      *
-     * @param int $id Context identifier
+     * @param string $id Context identifier
      *
      * @throws NotFoundHttpException
      *
@@ -204,7 +204,7 @@ class ContextController
     /**
      * Retrieves context with id $id or throws an exception if it doesn't exist.
      *
-     * @param int $id Context identifier
+     * @param string $id Context identifier
      *
      * @throws NotFoundHttpException
      *
@@ -224,8 +224,8 @@ class ContextController
     /**
      * Write a context, this method is used by both POST and PUT action methods.
      *
-     * @param Request  $request Symfony request
-     * @param int|null $id      context identifier
+     * @param Request     $request Symfony request
+     * @param string|null $id      context identifier
      *
      * @return FormInterface
      */

--- a/src/Controller/Api/TagController.php
+++ b/src/Controller/Api/TagController.php
@@ -80,7 +80,7 @@ class TagController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Tag identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Tag identifier"}
      *  },
      *  output={"class"="Sonata\ClassificationBundle\Model\Tag", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -91,9 +91,9 @@ class TagController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param mixed $id Tag identifier
+     * @param string $id Tag identifier
      *
-     * @return Tag
+     * @return TagInterface
      */
     public function getTagAction($id)
     {
@@ -129,7 +129,7 @@ class TagController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Tag identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Tag identifier"}
      *  },
      *  input={"class"="sonata_classification_api_form_tag", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="Sonata\ClassificationBundle\Model\Tag", "groups"={"sonata_api_read"}},
@@ -140,7 +140,7 @@ class TagController
      *  }
      * )
      *
-     * @param int     $id      Tag identifier
+     * @param string  $id      Tag identifier
      * @param Request $request Symfony request
      *
      * @throws NotFoundHttpException
@@ -157,7 +157,7 @@ class TagController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Tag identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Tag identifier"}
      *  },
      *  statusCodes={
      *      200="Returned when tag is successfully deleted",
@@ -166,7 +166,7 @@ class TagController
      *  }
      * )
      *
-     * @param int $id Tag identifier
+     * @param string $id Tag identifier
      *
      * @throws NotFoundHttpException
      *
@@ -204,7 +204,7 @@ class TagController
     /**
      * Retrieves tag with id $id or throws an exception if it doesn't exist.
      *
-     * @param int $id Tag identifier
+     * @param string $id Tag identifier
      *
      * @throws NotFoundHttpException
      *
@@ -224,8 +224,8 @@ class TagController
     /**
      * Write a tag, this method is used by both POST and PUT action methods.
      *
-     * @param Request  $request Symfony request
-     * @param int|null $id      Tag identifier
+     * @param Request     $request Symfony request
+     * @param string|null $id      Tag identifier
      *
      * @return FormInterface
      */


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Update OpenAPI (Swagger) definition in order to be compatible with string identifiers (like UUIDs).

These changes are consistent with the API narrowing made at sonata-project/admin-bundle (see AdminInterface::id()).

I am targeting this branch, because these changes respect BC.

Part of https://github.com/sonata-project/dev-kit/issues/778

Based on: https://github.com/sonata-project/SonataUserBundle/pull/1198

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataClassificationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed requirements that were only allowing integers for model identifiers at Open API definitions.
### Fixed
- Fixed support for string model identifiers at Open API definitions.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
