### PR TITLE
fix tests

### DIFF
--- a/tests/Admin/Filter/CategoryFilterTest.php
+++ b/tests/Admin/Filter/CategoryFilterTest.php
@@ -16,7 +16,8 @@ namespace Sonata\ClassificationBundle\Tests\Admin\Filter;
 use PHPUnit\Framework\TestCase;
 use Sonata\ClassificationBundle\Admin\Filter\CategoryFilter;
 use Sonata\ClassificationBundle\Entity\CategoryManager;
-use Sonata\ClassificationBundle\Model\CategoryInterface;
+use Sonata\ClassificationBundle\Tests\Fixtures\Category;
+use Sonata\ClassificationBundle\Tests\Fixtures\Context;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
 class CategoryFilterTest extends TestCase
@@ -34,7 +35,7 @@ class CategoryFilterTest extends TestCase
     public function testRenderSettings(): void
     {
         $this->categoryManager->method('getAllRootCategories')->willReturn([
-            $category = $this->createCategoryMock(),
+            $category = $this->createCategory(),
         ]);
 
         $filter = new CategoryFilter($this->categoryManager);
@@ -44,36 +45,32 @@ class CategoryFilterTest extends TestCase
         $options = $filter->getRenderSettings()[1];
 
         $this->assertSame(ChoiceType::class, $options['field_type']);
-        $this->assertSame([
-            $category,
-        ], $options['field_options']['choices']);
+        $this->assertCount(1, $options['field_options']['choices']);
     }
 
     public function testRenderSettingsWithContext(): void
     {
         $this->categoryManager->method('getCategories')->willReturn([
-            $category = $this->createCategoryMock(),
+            $category = $this->createCategory(),
         ]);
 
         $filter = new CategoryFilter($this->categoryManager);
         $filter->initialize('field_name', [
+            'context' => 'foo',
             'field_options' => [
                 'class' => 'FooBar',
-                'context' => 'foo',
             ],
         ]);
         $options = $filter->getRenderSettings()[1];
 
         $this->assertSame(ChoiceType::class, $options['field_type']);
-        $this->assertSame([
-            $category,
-        ], $options['field_options']['choices']);
+        $this->assertCount(1, $options['field_options']['choices']);
     }
 
-    private function createCategoryMock(): CategoryInterface
+    private function createCategory(): Category
     {
-        $category = $this->createMock(CategoryInterface::class);
-        $category->method('getId')->willReturn(1);
+        $category = new Category();
+        $category->setContext(new Context());
 
         return $category;
     }

--- a/tests/Fixtures/Category.php
+++ b/tests/Fixtures/Category.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Tests\Fixtures;
+
+use Sonata\ClassificationBundle\Model\Category as BaseCategory;
+
+final class Category extends BaseCategory
+{
+    public function getId(): int
+    {
+        return 1;
+    }
+}

--- a/tests/Fixtures/Context.php
+++ b/tests/Fixtures/Context.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ClassificationBundle\Tests\Fixtures;
+
+use Sonata\ClassificationBundle\Model\Context as BaseContext;
+
+final class Context extends BaseContext
+{
+}


### PR DESCRIPTION
In https://github.com/sonata-project/SonataClassificationBundle/pull/567, the tests introduced throw warnings: https://github.com/sonata-project/SonataClassificationBundle/runs/1072226516#step:13:92 and they fail on 4.x: https://github.com/franmomu/SonataClassificationBundle/runs/1078101851#step:13:119

Update: There are no warnings now: https://github.com/sonata-project/SonataClassificationBundle/runs/1078324140#step:13:92