### PR TITLE
Add conflict with doctrine/mongodb-odm <2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "twig/twig": "^2.12.1"
     },
     "conflict": {
+        "doctrine/mongodb-odm": "<2.0",
         "friendsofsymfony/rest-bundle": "<2.3",
         "jms/serializer": "<0.13",
         "nelmio/api-doc-bundle": "<2.13 || >=4.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Ref: https://github.com/sonata-project/dev-kit/issues/1069

We are dropping support for doctrine/mongodb-odm <2.0, this allows us to not install `alcaeus/mongo-php-adapter` in GA for tests.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/sonata-doctrine-extensions/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/sonata-doctrine-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Remove support for `doctrine/mongodb-odm` <2.0
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
