### PR TITLE
Add support for doctrine/persistence 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "require": {
         "php": "^7.2",
         "cocur/slugify": "^3.0 || ^4.0",
+        "doctrine/persistence": "^1.3.6 || ^2.0",
         "sonata-project/datagrid-bundle": "^2.3 || ^3.0",
         "sonata-project/doctrine-extensions": "^1.8",
         "sonata-project/form-extensions": "^0.1.1 || ^1.4",
@@ -48,7 +49,6 @@
     },
     "require-dev": {
         "doctrine/annotations": "^1.7",
-        "doctrine/persistence": "^1.3.6 || ^2.0",
         "friendsofsymfony/rest-bundle": "^2.3 || ^3.0",
         "jms/serializer-bundle": "^2.0 || ^3.0",
         "matthiasnoback/symfony-config-test": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
     },
     "require-dev": {
         "doctrine/annotations": "^1.7",
+        "doctrine/persistence": "^1.3.6 || ^2.0",
         "friendsofsymfony/rest-bundle": "^2.3 || ^3.0",
         "jms/serializer-bundle": "^2.0 || ^3.0",
         "matthiasnoback/symfony-config-test": "^4.0",

--- a/src/Entity/CategoryManager.php
+++ b/src/Entity/CategoryManager.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\ClassificationBundle\Entity;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextInterface;

--- a/tests/Entity/CategoryManagerTest.php
+++ b/tests/Entity/CategoryManagerTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\ClassificationBundle\Tests\Entity;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\ORM\AbstractQuery;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Entity/CategoryManagerTest.php
+++ b/tests/Entity/CategoryManagerTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\ClassificationBundle\Tests\Entity;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\ORM\AbstractQuery;
+use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\ClassificationBundle\Entity\BaseCategory;

--- a/tests/Entity/CollectionManagerTest.php
+++ b/tests/Entity/CollectionManagerTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\ClassificationBundle\Tests\Entity;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\ClassificationBundle\Entity\BaseCollection;

--- a/tests/Entity/ContextManagerTest.php
+++ b/tests/Entity/ContextManagerTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\ClassificationBundle\Tests\Entity;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\ClassificationBundle\Entity\BaseContext;

--- a/tests/Entity/TagManagerTest.php
+++ b/tests/Entity/TagManagerTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\ClassificationBundle\Tests\Entity;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\ClassificationBundle\Entity\BaseTag;


### PR DESCRIPTION
## Subject

Allow version 2 for "doctrine/persistence".

I am targeting this branch, because this change respects BC.

## Changelog

```markdown
### Added
- Added support for "doctrine/persistence:^2.0".
```
