### PR TITLE
Fix italian translations

### DIFF
--- a/src/Resources/translations/SonataClassificationBundle.it.xliff
+++ b/src/Resources/translations/SonataClassificationBundle.it.xliff
@@ -222,6 +222,26 @@
                 <source>Options</source>
                 <target>Opzioni</target>
             </trans-unit>
+            <trans-unit id="form.label_translation_domain">
+                <source>form.label_translation_domain</source>
+                <target>Dominio di traduzione</target>
+            </trans-unit>
+            <trans-unit id="form.label_icon">
+                <source>form.label_icon</source>
+                <target>Icona</target>
+            </trans-unit>
+            <trans-unit id="form.label_class">
+                <source>form.label_class</source>
+                <target>Classe CSS</target>
+            </trans-unit>
+            <trans-unit id="group_general">
+                <source>group_general</source>
+                <target>Generale</target>
+            </trans-unit>
+            <trans-unit id="group_options">
+                <source>group_options</source>
+                <target>Opzioni</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
## Fix italian translations

I am targeting this branch, because this is a minor improvement.

## Changelog

```markdown
### Added
- Missing translation keys

```