### PR TITLE
Fix controller paths

### DIFF
--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -19,17 +19,17 @@ Advanced Configuration
             admin:
                 tag:
                     class: Sonata\ClassificationBundle\Admin\TagAdmin
-                    controller: SonataAdminBundle:CRUD
+                    controller: Sonata\AdminBundle\Controller\CRUDController
                     translation: SonataClassificationBundle
                 category:
                     class: Sonata\ClassificationBundle\Admin\CategoryAdmin
-                    controller: SonataClassificationBundle:CategoryAdmin
+                    controller: Sonata\ClassificationBundle\Controller\CategoryAdminController
                     translation: SonataClassificationBundle
                 collection:
                     class: Sonata\ClassificationBundle\Admin\CollectionAdmin
-                    controller: SonataAdminBundle:CRUD
+                    controller: Sonata\AdminBundle\Controller\CRUDController
                     translation: SonataClassificationBundle
                 context:
                     class: Sonata\ClassificationBundle\Admin\ContextAdmin
-                    controller: SonataAdminBundle:CRUD
+                    controller: Sonata\AdminBundle\Controller\CRUDController
                     translation: SonataClassificationBundle

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,6 +13,12 @@ declare(strict_types=1);
 
 namespace Sonata\ClassificationBundle\DependencyInjection;
 
+use Sonata\AdminBundle\Controller\CRUDController;
+use Sonata\ClassificationBundle\Admin\CategoryAdmin;
+use Sonata\ClassificationBundle\Admin\CollectionAdmin;
+use Sonata\ClassificationBundle\Admin\ContextAdmin;
+use Sonata\ClassificationBundle\Admin\TagAdmin;
+use Sonata\ClassificationBundle\Controller\CategoryAdminController;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -47,32 +53,32 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('category')
                             ->addDefaultsIfNotSet()
                             ->children()
-                                ->scalarNode('class')->cannotBeEmpty()->defaultValue('Sonata\\ClassificationBundle\\Admin\\CategoryAdmin')->end()
-                                ->scalarNode('controller')->cannotBeEmpty()->defaultValue('SonataClassificationBundle:CategoryAdmin')->end()
+                                ->scalarNode('class')->cannotBeEmpty()->defaultValue(CategoryAdmin::class)->end()
+                                ->scalarNode('controller')->cannotBeEmpty()->defaultValue(CategoryAdminController::class)->end()
                                 ->scalarNode('translation')->cannotBeEmpty()->defaultValue('SonataClassificationBundle')->end()
                             ->end()
                         ->end()
                         ->arrayNode('tag')
                             ->addDefaultsIfNotSet()
                             ->children()
-                                ->scalarNode('class')->cannotBeEmpty()->defaultValue('Sonata\\ClassificationBundle\\Admin\\TagAdmin')->end()
-                                ->scalarNode('controller')->cannotBeEmpty()->defaultValue('SonataAdminBundle:CRUD')->end()
+                                ->scalarNode('class')->cannotBeEmpty()->defaultValue(TagAdmin::class)->end()
+                                ->scalarNode('controller')->cannotBeEmpty()->defaultValue(CRUDController::class)->end()
                                 ->scalarNode('translation')->cannotBeEmpty()->defaultValue('SonataClassificationBundle')->end()
                             ->end()
                         ->end()
                         ->arrayNode('collection')
                             ->addDefaultsIfNotSet()
                             ->children()
-                                ->scalarNode('class')->cannotBeEmpty()->defaultValue('Sonata\\ClassificationBundle\\Admin\\CollectionAdmin')->end()
-                                ->scalarNode('controller')->cannotBeEmpty()->defaultValue('SonataAdminBundle:CRUD')->end()
+                                ->scalarNode('class')->cannotBeEmpty()->defaultValue(CollectionAdmin::class)->end()
+                                ->scalarNode('controller')->cannotBeEmpty()->defaultValue(CRUDController::class)->end()
                                 ->scalarNode('translation')->cannotBeEmpty()->defaultValue('SonataClassificationBundle')->end()
                             ->end()
                         ->end()
                         ->arrayNode('context')
                             ->addDefaultsIfNotSet()
                             ->children()
-                                ->scalarNode('class')->cannotBeEmpty()->defaultValue('Sonata\\ClassificationBundle\\Admin\\ContextAdmin')->end()
-                                ->scalarNode('controller')->cannotBeEmpty()->defaultValue('SonataAdminBundle:CRUD')->end()
+                                ->scalarNode('class')->cannotBeEmpty()->defaultValue(ContextAdmin::class)->end()
+                                ->scalarNode('controller')->cannotBeEmpty()->defaultValue(CRUDController::class)->end()
                                 ->scalarNode('translation')->cannotBeEmpty()->defaultValue('SonataClassificationBundle')->end()
                             ->end()
                         ->end()

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -14,10 +14,12 @@ declare(strict_types=1);
 namespace Sonata\ClassificationBundle\Tests\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionConfigurationTestCase;
+use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\ClassificationBundle\Admin\CategoryAdmin;
 use Sonata\ClassificationBundle\Admin\CollectionAdmin;
 use Sonata\ClassificationBundle\Admin\ContextAdmin;
 use Sonata\ClassificationBundle\Admin\TagAdmin;
+use Sonata\ClassificationBundle\Controller\CategoryAdminController;
 use Sonata\ClassificationBundle\DependencyInjection\Configuration;
 use Sonata\ClassificationBundle\DependencyInjection\SonataClassificationExtension;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -38,22 +40,22 @@ final class ConfigurationTest extends AbstractExtensionConfigurationTestCase
             'admin' => [
                 'category' => [
                     'class' => CategoryAdmin::class,
-                    'controller' => 'SonataClassificationBundle:CategoryAdmin',
+                    'controller' => CategoryAdminController::class,
                     'translation' => 'SonataClassificationBundle',
                 ],
                 'tag' => [
                     'class' => TagAdmin::class,
-                    'controller' => 'SonataAdminBundle:CRUD',
+                    'controller' => CRUDController::class,
                     'translation' => 'SonataClassificationBundle',
                 ],
                 'collection' => [
                     'class' => CollectionAdmin::class,
-                    'controller' => 'SonataAdminBundle:CRUD',
+                    'controller' => CRUDController::class,
                     'translation' => 'SonataClassificationBundle',
                 ],
                 'context' => [
                     'class' => ContextAdmin::class,
-                    'controller' => 'SonataAdminBundle:CRUD',
+                    'controller' => CRUDController::class,
                     'translation' => 'SonataClassificationBundle',
                 ],
             ],

--- a/tests/DependencyInjection/SonataClassificationExtensionTest.php
+++ b/tests/DependencyInjection/SonataClassificationExtensionTest.php
@@ -15,6 +15,7 @@ namespace Sonata\ClassificationBundle\Tests\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Nelmio\ApiDocBundle\Annotation\Operation;
+use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\ClassificationBundle\Admin\CategoryAdmin;
 use Sonata\ClassificationBundle\Admin\CollectionAdmin;
 use Sonata\ClassificationBundle\Admin\ContextAdmin;
@@ -30,6 +31,7 @@ use Sonata\ClassificationBundle\Controller\Api\Legacy\CollectionController as Le
 use Sonata\ClassificationBundle\Controller\Api\Legacy\ContextController as LegacyContextController;
 use Sonata\ClassificationBundle\Controller\Api\Legacy\TagController as LegacyTagController;
 use Sonata\ClassificationBundle\Controller\Api\TagController;
+use Sonata\ClassificationBundle\Controller\CategoryAdminController;
 use Sonata\ClassificationBundle\DependencyInjection\SonataClassificationExtension;
 use Sonata\ClassificationBundle\Entity\CategoryManager;
 use Sonata\ClassificationBundle\Entity\CollectionManager;
@@ -104,19 +106,19 @@ final class SonataClassificationExtensionTest extends AbstractExtensionTestCase
 
         $this->assertContainerBuilderHasParameter('sonata.classification.admin.category.entity', 'Application\Sonata\ClassificationBundle\Entity\Category');
         $this->assertContainerBuilderHasParameter('sonata.classification.admin.category.class', CategoryAdmin::class);
-        $this->assertContainerBuilderHasParameter('sonata.classification.admin.category.controller', 'SonataClassificationBundle:CategoryAdmin');
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.category.controller', CategoryAdminController::class);
         $this->assertContainerBuilderHasParameter('sonata.classification.admin.category.translation_domain', 'SonataClassificationBundle');
         $this->assertContainerBuilderHasParameter('sonata.classification.admin.tag.entity', 'Application\Sonata\ClassificationBundle\Entity\Tag');
         $this->assertContainerBuilderHasParameter('sonata.classification.admin.tag.class', TagAdmin::class);
-        $this->assertContainerBuilderHasParameter('sonata.classification.admin.tag.controller', 'SonataAdminBundle:CRUD');
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.tag.controller', CRUDController::class);
         $this->assertContainerBuilderHasParameter('sonata.classification.admin.tag.translation_domain', 'SonataClassificationBundle');
         $this->assertContainerBuilderHasParameter('sonata.classification.admin.collection.entity', 'Application\Sonata\ClassificationBundle\Entity\Collection');
         $this->assertContainerBuilderHasParameter('sonata.classification.admin.collection.class', CollectionAdmin::class);
-        $this->assertContainerBuilderHasParameter('sonata.classification.admin.collection.controller', 'SonataAdminBundle:CRUD');
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.collection.controller', CRUDController::class);
         $this->assertContainerBuilderHasParameter('sonata.classification.admin.collection.translation_domain', 'SonataClassificationBundle');
         $this->assertContainerBuilderHasParameter('sonata.classification.admin.context.entity', 'Application\Sonata\ClassificationBundle\Entity\Context');
         $this->assertContainerBuilderHasParameter('sonata.classification.admin.context.class', ContextAdmin::class);
-        $this->assertContainerBuilderHasParameter('sonata.classification.admin.context.controller', 'SonataAdminBundle:CRUD');
+        $this->assertContainerBuilderHasParameter('sonata.classification.admin.context.controller', CRUDController::class);
         $this->assertContainerBuilderHasParameter('sonata.classification.admin.context.translation_domain', 'SonataClassificationBundle');
         $this->assertContainerBuilderHasParameter('sonata.classification.admin.groupname', 'sonata_classification');
         $this->assertContainerBuilderHasParameter('sonata.classification.admin.groupicon', "<i class='fa fa-tags'></i>");


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

```
  3x: Referencing controllers with SonataAdminBundle:CRUD:create is deprecated since Symfony 4.1, use "Sonata\AdminBundle\Controller\CRUDController::createAction" instead.
```

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a patch.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataClassificationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Remove controller deprecations
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
