### PR TITLE
Resolve some deprecation

### DIFF
--- a/src/Admin/Filter/CategoryFilter.php
+++ b/src/Admin/Filter/CategoryFilter.php
@@ -85,7 +85,7 @@ final class CategoryFilter extends Filter
         if (null === $context) {
             $categories = $this->categoryManager->getAllRootCategories();
         } else {
-            $categories = $this->categoryManager->getCategories($context);
+            $categories = $this->categoryManager->getRootCategoriesForContext($context);
         }
 
         $choices = [];

--- a/src/Block/Service/AbstractCategoriesBlockService.php
+++ b/src/Block/Service/AbstractCategoriesBlockService.php
@@ -59,7 +59,7 @@ abstract class AbstractCategoriesBlockService extends AbstractClassificationBloc
     public function execute(BlockContextInterface $blockContext, ?Response $response = null): Response
     {
         $category = $this->getCategory($blockContext->getSetting('categoryId'), $blockContext->getSetting('category'));
-        $root = $this->categoryManager->getRootCategory($blockContext->getSetting('context'));
+        $root = current($this->categoryManager->getRootCategoriesForContext($blockContext->getSetting('context')));
 
         return $this->renderResponse($blockContext->getTemplate(), [
             'context' => $blockContext,

--- a/src/Document/CategoryManager.php
+++ b/src/Document/CategoryManager.php
@@ -146,7 +146,7 @@ class CategoryManager extends BaseDocumentManager implements CategoryManagerInte
             ->createQueryBuilder('c')
             ->where('c.parent IS NULL')
             ->getQuery()
-            ->execute();
+            ->getResult();
 
         $categories = [];
 
@@ -207,7 +207,7 @@ class CategoryManager extends BaseDocumentManager implements CategoryManagerInte
             ->orderBy('c.parent')
             ->setParameter('context', $context->getId())
             ->getQuery()
-            ->execute();
+            ->getResult();
 
         if (0 === \count($categories)) {
             // no category, create one for the provided context

--- a/src/Document/CategoryManager.php
+++ b/src/Document/CategoryManager.php
@@ -109,10 +109,10 @@ class CategoryManager extends BaseDocumentManager implements CategoryManagerInte
     public function getRootCategoryWithChildren(CategoryInterface $category)
     {
         if (null === $category->getContext()) {
-            throw new \RuntimeException('Context cannot be null');
+            throw new \InvalidArgumentException('Context cannot be null.');
         }
         if (null !== $category->getParent()) {
-            throw new \RuntimeException('Method can be called only for root categories');
+            throw new \InvalidArgumentException('Method can be called only for root categories.');
         }
 
         $context = $category->getContext();
@@ -125,7 +125,7 @@ class CategoryManager extends BaseDocumentManager implements CategoryManagerInte
             }
         }
 
-        throw new \RuntimeException('Category does not exist');
+        throw new \InvalidArgumentException(sprintf('Category "%s" does not exist.', $category->getId()));
     }
 
     public function getRootCategoriesForContext(?ContextInterface $context = null)
@@ -148,7 +148,7 @@ class CategoryManager extends BaseDocumentManager implements CategoryManagerInte
 
         foreach ($rootCategories as $category) {
             if (null === $category->getContext()) {
-                throw new \RuntimeException('Context cannot be null');
+                throw new \LogicException('Context cannot be null.');
             }
 
             $categories[] = $loadChildren ? $this->getRootCategoryWithChildren($category) : $category;
@@ -215,7 +215,7 @@ class CategoryManager extends BaseDocumentManager implements CategoryManagerInte
 
         foreach ($categories as $pos => $category) {
             if (0 === $pos && $category->getParent()) {
-                throw new \RuntimeException('The first category must be the root');
+                throw new \LogicException('The first category must be the root.');
             }
 
             if (0 === $pos) {

--- a/src/Document/CategoryManager.php
+++ b/src/Document/CategoryManager.php
@@ -48,9 +48,10 @@ class CategoryManager extends BaseDocumentManager implements CategoryManagerInte
 
     public function getRootCategoriesPager($page = 1, $limit = 25, $criteria = [])
     {
-        $queryBuilder = $this->getObjectManager()->createQueryBuilder()
+        $queryBuilder = $this->getDocumentManager()
+            ->getRepository($this->class)
+            ->createQueryBuilder()
             ->select('c')
-            ->from($this->class, 'c')
             ->andWhere('c.parent IS NULL');
 
         $pager = new Pager($limit);
@@ -63,9 +64,10 @@ class CategoryManager extends BaseDocumentManager implements CategoryManagerInte
 
     public function getSubCategoriesPager($categoryId, $page = 1, $limit = 25, $criteria = [])
     {
-        $queryBuilder = $this->getObjectManager()->createQueryBuilder()
+        $queryBuilder = $this->getDocumentManager()
+            ->getRepository($this->class)
+            ->createQueryBuilder()
             ->select('c')
-            ->from($this->class, 'c')
             ->where('c.parent = :categoryId')
             ->setParameter('categoryId', $categoryId);
 
@@ -139,9 +141,11 @@ class CategoryManager extends BaseDocumentManager implements CategoryManagerInte
 
     public function getAllRootCategories($loadChildren = true)
     {
-        $class = $this->getClass();
-
-        $rootCategories = $this->getObjectManager()->createQuery(sprintf('SELECT c FROM %s c WHERE c.parent IS NULL', $class))
+        $rootCategories = $this->getDocumentManager()
+            ->getRepository($this->class)
+            ->createQueryBuilder('c')
+            ->where('c.parent IS NULL')
+            ->getQuery()
             ->execute();
 
         $categories = [];
@@ -196,8 +200,13 @@ class CategoryManager extends BaseDocumentManager implements CategoryManagerInte
             return;
         }
 
-        $categories = $this->getObjectManager()->createQuery(sprintf('SELECT c FROM %s c WHERE c.context = :context ORDER BY c.parent ASC', $this->getClass()))
+        $categories = $this->getDocumentManager()
+            ->getRepository($this->class)
+            ->createQueryBuilder('c')
+            ->where('c.context = :context')
+            ->orderBy('c.parent')
             ->setParameter('context', $context->getId())
+            ->getQuery()
             ->execute();
 
         if (0 === \count($categories)) {

--- a/src/Document/CategoryManager.php
+++ b/src/Document/CategoryManager.php
@@ -111,7 +111,10 @@ class CategoryManager extends BaseDocumentManager implements CategoryManagerInte
     public function getRootCategoryWithChildren(CategoryInterface $category)
     {
         if (null === $category->getContext()) {
-            throw new \InvalidArgumentException('Context cannot be null.');
+            throw new \InvalidArgumentException(sprintf(
+                'Context of category "%s" cannot be null.',
+                $category->getId()
+            ));
         }
         if (null !== $category->getParent()) {
             throw new \InvalidArgumentException('Method can be called only for root categories.');
@@ -152,7 +155,10 @@ class CategoryManager extends BaseDocumentManager implements CategoryManagerInte
 
         foreach ($rootCategories as $category) {
             if (null === $category->getContext()) {
-                throw new \LogicException('Context cannot be null.');
+                throw new \LogicException(sprintf(
+                    'Context of category "%s" cannot be null.',
+                    $category->getId()
+                ));
             }
 
             $categories[] = $loadChildren ? $this->getRootCategoryWithChildren($category) : $category;

--- a/src/Entity/CategoryManager.php
+++ b/src/Entity/CategoryManager.php
@@ -86,10 +86,10 @@ class CategoryManager extends BaseEntityManager implements CategoryManagerInterf
     public function getRootCategoryWithChildren(CategoryInterface $category)
     {
         if (null === $category->getContext()) {
-            throw new \RuntimeException('Context cannot be null');
+            throw new \InvalidArgumentException('Context cannot be null.');
         }
         if (null !== $category->getParent()) {
-            throw new \RuntimeException('Method can be called only for root categories');
+            throw new \InvalidArgumentException('Method can be called only for root categories.');
         }
 
         $context = $category->getContext();
@@ -102,7 +102,7 @@ class CategoryManager extends BaseEntityManager implements CategoryManagerInterf
             }
         }
 
-        throw new \RuntimeException('Category does not exist');
+        throw new \InvalidArgumentException(sprintf('Category "%s" does not exist.', $category->getId()));
     }
 
     public function getRootCategoriesForContext(?ContextInterface $context = null)
@@ -127,7 +127,7 @@ class CategoryManager extends BaseEntityManager implements CategoryManagerInterf
 
         foreach ($rootCategories as $category) {
             if (null === $category->getContext()) {
-                throw new \RuntimeException('Context cannot be null');
+                throw new \LogicException('Context cannot be null.');
             }
 
             $categories[] = $loadChildren ? $this->getRootCategoryWithChildren($category) : $category;

--- a/src/Entity/CategoryManager.php
+++ b/src/Entity/CategoryManager.php
@@ -118,9 +118,10 @@ class CategoryManager extends BaseEntityManager implements CategoryManagerInterf
 
     public function getAllRootCategories($loadChildren = true)
     {
-        $class = $this->getClass();
-
-        $rootCategories = $this->getObjectManager()->createQuery(sprintf('SELECT c FROM %s c WHERE c.parent IS NULL', $class))
+        $rootCategories = $this->getRepository()
+            ->createQueryBuilder('c')
+            ->where('c.parent IS NULL')
+            ->getQuery()
             ->execute();
 
         $categories = [];
@@ -204,10 +205,12 @@ class CategoryManager extends BaseEntityManager implements CategoryManagerInterf
             return;
         }
 
-        $class = $this->getClass();
-
-        $categories = $this->getObjectManager()->createQuery(sprintf('SELECT c FROM %s c WHERE c.context = :context ORDER BY c.parent ASC', $class))
+        $categories = $this->getRepository()
+            ->createQueryBuilder('c')
+            ->where('c.context = :context')
+            ->orderBy('c.parent')
             ->setParameter('context', $context->getId())
+            ->getQuery()
             ->execute();
 
         if (0 === \count($categories)) {

--- a/src/Entity/CategoryManager.php
+++ b/src/Entity/CategoryManager.php
@@ -86,7 +86,10 @@ class CategoryManager extends BaseEntityManager implements CategoryManagerInterf
     public function getRootCategoryWithChildren(CategoryInterface $category)
     {
         if (null === $category->getContext()) {
-            throw new \InvalidArgumentException('Context cannot be null.');
+            throw new \InvalidArgumentException(sprintf(
+                'Context of category "%s" cannot be null.',
+                $category->getId()
+            ));
         }
         if (null !== $category->getParent()) {
             throw new \InvalidArgumentException('Method can be called only for root categories.');
@@ -128,7 +131,10 @@ class CategoryManager extends BaseEntityManager implements CategoryManagerInterf
 
         foreach ($rootCategories as $category) {
             if (null === $category->getContext()) {
-                throw new \LogicException('Context cannot be null.');
+                throw new \LogicException(sprintf(
+                    'Context of category "%s" cannot be null.',
+                    $category->getId()
+                ));
             }
 
             $categories[] = $loadChildren ? $this->getRootCategoryWithChildren($category) : $category;

--- a/src/Entity/CategoryManager.php
+++ b/src/Entity/CategoryManager.php
@@ -122,7 +122,7 @@ class CategoryManager extends BaseEntityManager implements CategoryManagerInterf
             ->createQueryBuilder('c')
             ->where('c.parent IS NULL')
             ->getQuery()
-            ->execute();
+            ->getResult();
 
         $categories = [];
 
@@ -211,7 +211,7 @@ class CategoryManager extends BaseEntityManager implements CategoryManagerInterf
             ->orderBy('c.parent')
             ->setParameter('context', $context->getId())
             ->getQuery()
-            ->execute();
+            ->getResult();
 
         if (0 === \count($categories)) {
             // no category, create one for the provided context

--- a/src/Model/Category.php
+++ b/src/Model/Category.php
@@ -64,7 +64,7 @@ abstract class Category implements CategoryInterface
     protected $parent;
 
     /**
-     * @var ContextInterface
+     * @var ContextInterface|null
      */
     protected $context;
 

--- a/src/Model/CategoryInterface.php
+++ b/src/Model/CategoryInterface.php
@@ -135,7 +135,7 @@ interface CategoryInterface
     public function setContext(ContextInterface $context);
 
     /**
-     * @return ContextInterface
+     * @return ContextInterface|null
      */
     public function getContext();
 }

--- a/src/Model/CategoryManagerInterface.php
+++ b/src/Model/CategoryManagerInterface.php
@@ -18,14 +18,6 @@ use Sonata\DatagridBundle\Pager\PageableInterface;
 use Sonata\Doctrine\Model\ManagerInterface;
 
 /**
- * @method PagerInterface         getRootCategoriesPager(int $page = 1, int $limit = 25, array $criteria = [])
- * @method PagerInterface         getSubCategoriesPager(int $categoryId, int $page = 1, int $limit = 25, array $criteria = [])
- * @method CategoryInterface[]    getRootCategoriesForContext(ContextInterface|null $context)
- * @method CategoryInterface[]    getAllRootCategories(bool $loadChildren = true)
- * @method CategoryInterface[]    getRootCategoriesSplitByContexts(bool $loadChildren = true)
- * @method CategoryInterface[]    getCategories(ContextInterface|string|null $context)
- * @method CategoryInterface|null getBySlug(string $slug, ContextInterface|string|null $context, bool $enabled = true)
- *
  * @phpstan-extends ManagerInterface<CategoryInterface>
  * @phpstan-extends PageableInterface<CategoryInterface>
  */
@@ -58,27 +50,6 @@ interface CategoryManagerInterface extends ManagerInterface, PageableInterface
     public function getRootCategoryWithChildren(CategoryInterface $category);
 
     /**
-     * @param bool $loadChildren
-     *
-     * @return CategoryInterface[]
-     */
-    public function getRootCategories($loadChildren = true);
-
-    /**
-     * @param ContextInterface|string $context
-     *
-     * @return CategoryInterface[]
-     */
-    public function getCategories($context = null);
-
-    /**
-     * @param ContextInterface|string $context
-     *
-     * @return CategoryInterface
-     */
-    public function getRootCategory($context = null);
-
-    /**
      * @param ContextInterface $context
      *
      * @return CategoryInterface[]
@@ -98,4 +69,11 @@ interface CategoryManagerInterface extends ManagerInterface, PageableInterface
      * @return array
      */
     public function getRootCategoriesSplitByContexts($loadChildren = true);
+
+    /**
+     * @param ContextInterface|string|null $context
+     *
+     * @return CategoryInterface|null
+     */
+    public function getBySlug(string $slug, $context = null, ?bool $enabled = true);
 }

--- a/tests/Admin/Filter/CategoryFilterTest.php
+++ b/tests/Admin/Filter/CategoryFilterTest.php
@@ -51,13 +51,13 @@ class CategoryFilterTest extends TestCase
 
     public function testRenderSettingsWithContext(): void
     {
-        $this->categoryManager->method('getCategories')->willReturn([
+        $this->categoryManager->method('getRootCategoriesForContext')->willReturn([
             $category = $this->createCategory(),
         ]);
 
         $filter = new CategoryFilter($this->categoryManager);
         $filter->initialize('field_name', [
-            'context' => 'foo',
+            'context' => new Context(),
             'field_options' => [
                 'class' => 'FooBar',
             ],

--- a/tests/Entity/CategoryManagerTest.php
+++ b/tests/Entity/CategoryManagerTest.php
@@ -76,38 +76,6 @@ class CategoryManagerTest extends TestCase
             ], 1);
     }
 
-    public function testGetCategoriesWithMultipleRootsInContext(): void
-    {
-        /** @var ContextTest $context */
-        $context = $this->getMockForAbstractClass(ContextTest::class);
-        $context->setId(1);
-        $context->setName('default');
-        $context->setEnabled(true);
-
-        /** @var CategoryTest $categoryFoo */
-        $categoryFoo = $this->getMockForAbstractClass(CategoryTest::class);
-        $categoryFoo->setId(1);
-        $categoryFoo->setName('foo');
-        $categoryFoo->setContext($context);
-        $categoryFoo->setParent(null);
-        $categoryFoo->setEnabled(true);
-
-        /** @var CategoryTest $categoryBar */
-        $categoryBar = $this->getMockForAbstractClass(CategoryTest::class);
-        $categoryBar->setId(2);
-        $categoryBar->setName('bar');
-        $categoryBar->setContext($context);
-        $categoryBar->setParent(null);
-        $categoryBar->setEnabled(true);
-
-        $categories = [$categoryFoo, $categoryBar];
-
-        $categoryManager = $this->getCategoryManager(static function (MockObject $qb): void {
-        }, $categories);
-
-        $this->assertSame($categoryManager->getCategories($context), $categories);
-    }
-
     public function testGetRootCategoryWithChildren(): void
     {
         /** @var ContextTest $context */
@@ -137,29 +105,6 @@ class CategoryManagerTest extends TestCase
 
         $categoryFoo = $categoryManager->getRootCategoryWithChildren($categoryFoo);
         $this->assertContains($categoryBar, $categoryFoo->getChildren());
-    }
-
-    public function testGetRootCategory(): void
-    {
-        /** @var ContextTest $context */
-        $context = $this->getMockForAbstractClass(ContextTest::class);
-        $context->setId(1);
-        $context->setName('default');
-        $context->setEnabled(true);
-
-        /** @var CategoryTest $categoryFoo */
-        $categoryFoo = $this->getMockForAbstractClass(CategoryTest::class);
-        $categoryFoo->setId(1);
-        $categoryFoo->setName('foo');
-        $categoryFoo->setContext($context);
-        $categoryFoo->setParent(null);
-        $categoryFoo->setEnabled(true);
-
-        $categoryManager = $this->getCategoryManager(static function (MockObject $qb): void {
-        }, [$categoryFoo]);
-
-        $categoryBar = $categoryManager->getRootCategory($context);
-        $this->assertSame($categoryFoo, $categoryBar);
     }
 
     public function testGetRootCategoriesForContext(): void
@@ -192,46 +137,6 @@ class CategoryManagerTest extends TestCase
         $categories = $categoryManager->getRootCategoriesForContext($context);
         $this->assertCount(1, $categories);
         $this->assertContains($categoryFoo, $categories);
-    }
-
-    public function testGetRootCategories(): void
-    {
-        /** @var ContextTest $contextFoo */
-        $contextFoo = $this->getMockForAbstractClass(ContextTest::class);
-        $contextFoo->setId(1);
-        $contextFoo->setName('foo');
-        $contextFoo->setEnabled(true);
-
-        /** @var ContextTest $contextBar */
-        $contextBar = $this->getMockForAbstractClass(ContextTest::class);
-        $contextBar->setId(2);
-        $contextBar->setName('bar');
-        $contextBar->setEnabled(true);
-
-        /** @var CategoryTest $categoryFoo */
-        $categoryFoo = $this->getMockForAbstractClass(CategoryTest::class);
-        $categoryFoo->setId(1);
-        $categoryFoo->setName('foo');
-        $categoryFoo->setContext($contextFoo);
-        $categoryFoo->setParent(null);
-        $categoryFoo->setEnabled(true);
-
-        /** @var CategoryTest $categoryBar */
-        $categoryBar = $this->getMockForAbstractClass(CategoryTest::class);
-        $categoryBar->setId(2);
-        $categoryBar->setName('bar');
-        $categoryBar->setContext($contextBar);
-        $categoryBar->setParent(null);
-        $categoryBar->setEnabled(true);
-
-        $categoryManager = $this->getCategoryManager(static function (MockObject $qb): void {
-        }, [$categoryFoo, $categoryBar]);
-
-        $categories = $categoryManager->getRootCategories(false);
-        $this->assertArrayHasKey($contextFoo->getId(), $categories);
-        $this->assertArrayHasKey($contextBar->getId(), $categories);
-        $this->assertSame($categoryFoo, $categories[$contextFoo->getId()]);
-        $this->assertSame($categoryBar, $categories[$contextBar->getId()]);
     }
 
     public function testGetRootCategoriesSplitByContexts(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because BC-break.

## Changelog

```markdown
### Removed
- `CategoryManager:: getRootCategory()` use `getRootCategoriesForContext()` instead
- `CategoryManager:: getRootCategories()` use `getAllRootCategories()` instead
- `CategoryManager:: getCategories()` use `getRootCategoriesForContext()` instead
- `CategoryManagerInterface:: getRootCategory()` use `getRootCategoriesForContext()` instead
- `CategoryManagerInterface:: getRootCategories()` use `getAllRootCategories()` instead
- `CategoryManagerInterface:: getCategories()` use `getRootCategoriesForContext()` instead
```