### PR TITLE
Make blocks editable

### DIFF
--- a/src/Block/Service/AbstractCategoriesBlockService.php
+++ b/src/Block/Service/AbstractCategoriesBlockService.php
@@ -14,8 +14,9 @@ declare(strict_types=1);
 namespace Sonata\ClassificationBundle\Block\Service;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\EditableBlockService;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Meta\Metadata;
 use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
@@ -23,6 +24,7 @@ use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 use Sonata\Form\Type\ImmutableArrayType;
+use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
@@ -32,7 +34,7 @@ use Twig\Environment;
 /**
  * @author Christian Gripp <mail@core23.de>
  */
-abstract class AbstractCategoriesBlockService extends AbstractClassificationBlockService
+abstract class AbstractCategoriesBlockService extends AbstractClassificationBlockService implements EditableBlockService
 {
     /**
      * @var CategoryManagerInterface
@@ -70,13 +72,18 @@ abstract class AbstractCategoriesBlockService extends AbstractClassificationBloc
         ], $response);
     }
 
-    public function buildEditForm(FormMapper $formMapper, BlockInterface $block): void
+    public function configureCreateForm(FormMapper $form, BlockInterface $block): void
+    {
+        $this->configureEditForm($form, $block);
+    }
+
+    public function configureEditForm(FormMapper $form, BlockInterface $block): void
     {
         if (null === $this->categoryAdmin) {
             throw new \BadMethodCallException('You need the sonata-project/admin-bundle library to edit this block.');
         }
 
-        $adminField = $this->getFormAdminType($formMapper, $this->categoryAdmin, 'categoryId', 'category', [
+        $adminField = $this->getFormAdminType($form, $this->categoryAdmin, 'categoryId', 'category', [
             'label' => 'form.label_category',
         ], [
             'translation_domain' => 'SonataClassificationBundle',
@@ -89,7 +96,7 @@ abstract class AbstractCategoriesBlockService extends AbstractClassificationBloc
             ],
         ]);
 
-        $formMapper->add(
+        $form->add(
             'settings',
             ImmutableArrayType::class,
             [
@@ -120,6 +127,10 @@ abstract class AbstractCategoriesBlockService extends AbstractClassificationBloc
                 'translation_domain' => 'SonataClassificationBundle',
             ]
         );
+    }
+
+    public function validate(ErrorElement $errorElement, BlockInterface $block): void
+    {
     }
 
     public function configureSettings(OptionsResolver $resolver): void

--- a/src/Block/Service/AbstractCollectionsBlockService.php
+++ b/src/Block/Service/AbstractCollectionsBlockService.php
@@ -14,8 +14,9 @@ declare(strict_types=1);
 namespace Sonata\ClassificationBundle\Block\Service;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\EditableBlockService;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Meta\Metadata;
 use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
@@ -23,6 +24,7 @@ use Sonata\ClassificationBundle\Model\CollectionInterface;
 use Sonata\ClassificationBundle\Model\CollectionManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 use Sonata\Form\Type\ImmutableArrayType;
+use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
@@ -32,7 +34,7 @@ use Twig\Environment;
 /**
  * @author Christian Gripp <mail@core23.de>
  */
-abstract class AbstractCollectionsBlockService extends AbstractClassificationBlockService
+abstract class AbstractCollectionsBlockService extends AbstractClassificationBlockService implements EditableBlockService
 {
     /**
      * @var CollectionManagerInterface
@@ -73,13 +75,18 @@ abstract class AbstractCollectionsBlockService extends AbstractClassificationBlo
         ], $response);
     }
 
-    public function buildEditForm(FormMapper $formMapper, BlockInterface $block): void
+    public function configureCreateForm(FormMapper $form, BlockInterface $block): void
+    {
+        $this->configureEditForm($form, $block);
+    }
+
+    public function configureEditForm(FormMapper $form, BlockInterface $block): void
     {
         if (null === $this->collectionAdmin) {
             throw new \BadMethodCallException('You need the sonata-project/admin-bundle library to edit this block.');
         }
 
-        $adminField = $this->getFormAdminType($formMapper, $this->collectionAdmin, 'collectionId', 'collection', [
+        $adminField = $this->getFormAdminType($form, $this->collectionAdmin, 'collectionId', 'collection', [
             'label' => 'form.label_collection',
         ], [
             'translation_domain' => 'SonataClassificationBundle',
@@ -90,7 +97,7 @@ abstract class AbstractCollectionsBlockService extends AbstractClassificationBlo
             ],
         ]);
 
-        $formMapper->add(
+        $form->add(
             'settings',
             ImmutableArrayType::class,
             [
@@ -121,6 +128,10 @@ abstract class AbstractCollectionsBlockService extends AbstractClassificationBlo
                 'translation_domain' => 'SonataClassificationBundle',
             ]
         );
+    }
+
+    public function validate(ErrorElement $errorElement, BlockInterface $block): void
+    {
     }
 
     public function configureSettings(OptionsResolver $resolver): void

--- a/src/Block/Service/AbstractTagsBlockService.php
+++ b/src/Block/Service/AbstractTagsBlockService.php
@@ -14,8 +14,9 @@ declare(strict_types=1);
 namespace Sonata\ClassificationBundle\Block\Service;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\EditableBlockService;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Meta\Metadata;
 use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
@@ -23,6 +24,7 @@ use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 use Sonata\ClassificationBundle\Model\TagInterface;
 use Sonata\ClassificationBundle\Model\TagManagerInterface;
 use Sonata\Form\Type\ImmutableArrayType;
+use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
@@ -32,7 +34,7 @@ use Twig\Environment;
 /**
  * @author Christian Gripp <mail@core23.de>
  */
-abstract class AbstractTagsBlockService extends AbstractClassificationBlockService
+abstract class AbstractTagsBlockService extends AbstractClassificationBlockService implements EditableBlockService
 {
     /**
      * @var TagManagerInterface
@@ -73,13 +75,18 @@ abstract class AbstractTagsBlockService extends AbstractClassificationBlockServi
         ], $response);
     }
 
-    public function buildEditForm(FormMapper $formMapper, BlockInterface $block): void
+    public function configureCreateForm(FormMapper $form, BlockInterface $block): void
+    {
+        $this->configureEditForm($form, $block);
+    }
+
+    public function configureEditForm(FormMapper $form, BlockInterface $block): void
     {
         if (null === $this->tagAdmin) {
             throw new \BadMethodCallException('You need the sonata-project/admin-bundle library to edit this block.');
         }
 
-        $adminField = $this->getFormAdminType($formMapper, $this->tagAdmin, 'tagId', 'tag', [
+        $adminField = $this->getFormAdminType($form, $this->tagAdmin, 'tagId', 'tag', [
             'label' => 'form.label_tag',
         ], [
             'translation_domain' => 'SonataClassificationBundle',
@@ -90,7 +97,7 @@ abstract class AbstractTagsBlockService extends AbstractClassificationBlockServi
             ],
         ]);
 
-        $formMapper->add(
+        $form->add(
             'settings',
             ImmutableArrayType::class,
             [
@@ -121,6 +128,10 @@ abstract class AbstractTagsBlockService extends AbstractClassificationBlockServi
                 'translation_domain' => 'SonataClassificationBundle',
             ]
         );
+    }
+
+    public function validate(ErrorElement $errorElement, BlockInterface $block): void
+    {
     }
 
     public function configureSettings(OptionsResolver $resolver): void


### PR DESCRIPTION

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataClassificationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Make blocks editable
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
