### PR TITLE
Deprecate non used methods

### DIFF
--- a/src/Entity/CategoryManager.php
+++ b/src/Entity/CategoryManager.php
@@ -50,9 +50,19 @@ class CategoryManager extends BaseEntityManager implements CategoryManagerInterf
 
     /**
      * Returns a pager to iterate over the root category.
+     *
+     * @deprecated since sonata-project/classification-bundle 3.x, to be removed in 4.0.
      */
     public function getRootCategoriesPager($page = 1, $limit = 25, $criteria = [])
     {
+        @trigger_error(
+            sprintf(
+                'The method %s is deprecated since sonata-project/classification-bundle 3.x and will be removed in 4.0.',
+                __METHOD__
+            ),
+            \E_USER_DEPRECATED
+        );
+
         $page = 0 === (int) $page ? 1 : (int) $page;
 
         $queryBuilder = $this->getEntityManager()->createQueryBuilder()
@@ -68,8 +78,19 @@ class CategoryManager extends BaseEntityManager implements CategoryManagerInterf
         return $pager;
     }
 
+    /**
+     * @deprecated since sonata-project/classification-bundle 3.x, to be removed in 4.0.
+     */
     public function getSubCategoriesPager($categoryId, $page = 1, $limit = 25, $criteria = [])
     {
+        @trigger_error(
+            sprintf(
+                'The method %s is deprecated since sonata-project/classification-bundle 3.x and will be removed in 4.0.',
+                __METHOD__
+            ),
+            \E_USER_DEPRECATED
+        );
+
         $queryBuilder = $this->getEntityManager()->createQueryBuilder()
             ->select('c')
             ->from($this->class, 'c')

--- a/src/Model/CategoryManagerInterface.php
+++ b/src/Model/CategoryManagerInterface.php
@@ -13,15 +13,12 @@ declare(strict_types=1);
 
 namespace Sonata\ClassificationBundle\Model;
 
-use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\Doctrine\Model\PageableManagerInterface;
 
 /**
  * NEXT_MAJOR: Remove PageableManagerInterface extension.
  *
- * @method PagerInterface         getRootCategoriesPager(int $page = 1, int $limit = 25, array $criteria = [])
- * @method PagerInterface         getSubCategoriesPager(int $categoryId, int $page = 1, int $limit = 25, array $criteria = [])
  * @method CategoryInterface[]    getRootCategoriesForContext(ContextInterface|null $context)
  * @method CategoryInterface[]    getAllRootCategories(bool $loadChildren = true)
  * @method CategoryInterface[]    getRootCategoriesSplitByContexts(bool $loadChildren = true)


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

https://github.com/sonata-project/SonataClassificationBundle/pull/759#issuecomment-956306157

## Changelog

```markdown
### Deprecated
- CategoryManager::getRootCategoriesPager()
- CategoryManager::getSubCategoriesPager()
```