### PR TITLE
Deprecate disableChildrenLazyLoading

### DIFF
--- a/src/Entity/BaseCategory.php
+++ b/src/Entity/BaseCategory.php
@@ -18,8 +18,19 @@ use Sonata\ClassificationBundle\Model\Category as ModelCategory;
 
 abstract class BaseCategory extends ModelCategory
 {
+    /**
+     * @deprecated since sonata-project/classification-bundle 3.x, to be removed in 4.0.
+     */
     public function disableChildrenLazyLoading()
     {
+        @trigger_error(
+            sprintf(
+                'The method %s is deprecated since sonata-project/classification-bundle 3.x and will be removed in 4.0.',
+                __METHOD__
+            ),
+            \E_USER_DEPRECATED
+        );
+
         if ($this->children instanceof PersistentCollection) {
             $this->children->setInitialized(true);
         }

--- a/src/Entity/CategoryManager.php
+++ b/src/Entity/CategoryManager.php
@@ -312,8 +312,6 @@ class CategoryManager extends BaseEntityManager implements CategoryManagerInterf
 
             $parent = $category->getParent();
 
-            $category->disableChildrenLazyLoading();
-
             if ($parent) {
                 $parent->addChild($category);
             }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because BC

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataClassificationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `BaseCategory::disableChildrenLazyLoading()`
```