### PR TITLE
Fix CategoryInterface getSlug phpdoc

### DIFF
--- a/src/Model/CategoryInterface.php
+++ b/src/Model/CategoryInterface.php
@@ -52,7 +52,7 @@ interface CategoryInterface
     public function getEnabled();
 
     /**
-     * @param int $slug
+     * @param string|null $slug
      */
     public function setSlug($slug);
 


### PR DESCRIPTION
## Fix CategoryInterface getSlug phpdoc

Fixes the wrong return type of the getSlug method in the CategoryInterface. The old return type (int) causes phpstan errors in the project.

I am targeting this branch, because because the problem is already corrected in the other branches..

## Changelog


```markdown
### Fixed
- Fixed CategoryInterface::getSlug() PHPDoc return type.

```
