### PR TITLE
Remove final for getter/setters

### DIFF
--- a/src/Model/Category.php
+++ b/src/Model/Category.php
@@ -51,44 +51,44 @@ abstract class Category implements CategoryInterface
         return $this->getName() ?? 'n/a';
     }
 
-    final public function setName(?string $name): void
+    public function setName(?string $name): void
     {
         $this->name = $name;
 
         $this->setSlug($name);
     }
 
-    final public function getName(): ?string
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    final public function setEnabled(bool $enabled): void
+    public function setEnabled(bool $enabled): void
     {
         $this->enabled = $enabled;
     }
 
-    final public function getEnabled(): bool
+    public function getEnabled(): bool
     {
         return $this->enabled;
     }
 
-    final public function setSlug(?string $slug): void
+    public function setSlug(?string $slug): void
     {
         $this->slug = Tag::slugify($slug ?? '');
     }
 
-    final public function getSlug(): ?string
+    public function getSlug(): ?string
     {
         return $this->slug;
     }
 
-    final public function setDescription(?string $description): void
+    public function setDescription(?string $description): void
     {
         $this->description = $description;
     }
 
-    final public function getDescription(): ?string
+    public function getDescription(): ?string
     {
         return $this->description;
     }
@@ -104,37 +104,37 @@ abstract class Category implements CategoryInterface
         $this->setUpdatedAt(new \DateTime());
     }
 
-    final public function setCreatedAt(?\DateTimeInterface $createdAt): void
+    public function setCreatedAt(?\DateTimeInterface $createdAt): void
     {
         $this->createdAt = $createdAt;
     }
 
-    final public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeInterface
     {
         return $this->createdAt;
     }
 
-    final public function setUpdatedAt(?\DateTimeInterface $updatedAt): void
+    public function setUpdatedAt(?\DateTimeInterface $updatedAt): void
     {
         $this->updatedAt = $updatedAt;
     }
 
-    final public function getUpdatedAt(): ?\DateTimeInterface
+    public function getUpdatedAt(): ?\DateTimeInterface
     {
         return $this->updatedAt;
     }
 
-    final public function setPosition(?int $position): void
+    public function setPosition(?int $position): void
     {
         $this->position = $position;
     }
 
-    final public function getPosition(): ?int
+    public function getPosition(): ?int
     {
         return $this->position;
     }
 
-    final public function addChild(CategoryInterface $child, bool $nested = false): void
+    public function addChild(CategoryInterface $child, bool $nested = false): void
     {
         $this->children[] = $child;
 
@@ -147,7 +147,7 @@ abstract class Category implements CategoryInterface
         }
     }
 
-    final public function removeChild(CategoryInterface $childToDelete): void
+    public function removeChild(CategoryInterface $childToDelete): void
     {
         foreach ($this->getChildren() as $pos => $child) {
             if (null !== $childToDelete->getId() && $child->getId() === $childToDelete->getId()) {
@@ -164,12 +164,12 @@ abstract class Category implements CategoryInterface
         }
     }
 
-    final public function getChildren(): Collection
+    public function getChildren(): Collection
     {
         return $this->children;
     }
 
-    final public function setChildren(array $children): void
+    public function setChildren(array $children): void
     {
         $this->children = new ArrayCollection();
 
@@ -178,12 +178,12 @@ abstract class Category implements CategoryInterface
         }
     }
 
-    final public function hasChildren(): bool
+    public function hasChildren(): bool
     {
         return \count($this->children) > 0;
     }
 
-    final public function setParent(?CategoryInterface $parent = null, bool $nested = false): void
+    public function setParent(?CategoryInterface $parent = null, bool $nested = false): void
     {
         $this->parent = $parent;
 
@@ -192,17 +192,17 @@ abstract class Category implements CategoryInterface
         }
     }
 
-    final public function getParent(): ?CategoryInterface
+    public function getParent(): ?CategoryInterface
     {
         return $this->parent;
     }
 
-    final public function setContext(?ContextInterface $context): void
+    public function setContext(?ContextInterface $context): void
     {
         $this->context = $context;
     }
 
-    final public function getContext(): ?ContextInterface
+    public function getContext(): ?ContextInterface
     {
         return $this->context;
     }

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -41,37 +41,37 @@ abstract class Collection implements CollectionInterface
         $this->setSlug($name);
     }
 
-    final public function getName(): ?string
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    final public function setEnabled(bool $enabled): void
+    public function setEnabled(bool $enabled): void
     {
         $this->enabled = $enabled;
     }
 
-    final public function getEnabled(): bool
+    public function getEnabled(): bool
     {
         return $this->enabled;
     }
 
-    final public function setSlug(?string $slug): void
+    public function setSlug(?string $slug): void
     {
         $this->slug = Tag::slugify($slug ?? '');
     }
 
-    final public function getSlug(): ?string
+    public function getSlug(): ?string
     {
         return $this->slug;
     }
 
-    final public function setDescription(?string $description): void
+    public function setDescription(?string $description): void
     {
         $this->description = $description;
     }
 
-    final public function getDescription(): ?string
+    public function getDescription(): ?string
     {
         return $this->description;
     }
@@ -87,32 +87,32 @@ abstract class Collection implements CollectionInterface
         $this->setUpdatedAt(new \DateTime());
     }
 
-    final public function setCreatedAt(?\DateTimeInterface $createdAt): void
+    public function setCreatedAt(?\DateTimeInterface $createdAt): void
     {
         $this->createdAt = $createdAt;
     }
 
-    final public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeInterface
     {
         return $this->createdAt;
     }
 
-    final public function setUpdatedAt(?\DateTimeInterface $updatedAt): void
+    public function setUpdatedAt(?\DateTimeInterface $updatedAt): void
     {
         $this->updatedAt = $updatedAt;
     }
 
-    final public function getUpdatedAt(): ?\DateTimeInterface
+    public function getUpdatedAt(): ?\DateTimeInterface
     {
         return $this->updatedAt;
     }
 
-    final public function setContext(?ContextInterface $context): void
+    public function setContext(?ContextInterface $context): void
     {
         $this->context = $context;
     }
 
-    final public function getContext(): ?ContextInterface
+    public function getContext(): ?ContextInterface
     {
         return $this->context;
     }

--- a/src/Model/Context.php
+++ b/src/Model/Context.php
@@ -30,42 +30,42 @@ abstract class Context implements ContextInterface
         return $this->getName() ?? 'n/a';
     }
 
-    final public function setName(?string $name): void
+    public function setName(?string $name): void
     {
         $this->name = $name;
     }
 
-    final public function getName(): ?string
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    final public function setEnabled(bool $enabled): void
+    public function setEnabled(bool $enabled): void
     {
         $this->enabled = $enabled;
     }
 
-    final public function getEnabled(): bool
+    public function getEnabled(): bool
     {
         return $this->enabled;
     }
 
-    final public function setCreatedAt(?\DateTimeInterface $createdAt): void
+    public function setCreatedAt(?\DateTimeInterface $createdAt): void
     {
         $this->createdAt = $createdAt;
     }
 
-    final public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeInterface
     {
         return $this->createdAt;
     }
 
-    final public function setUpdatedAt(?\DateTimeInterface $updatedAt): void
+    public function setUpdatedAt(?\DateTimeInterface $updatedAt): void
     {
         $this->updatedAt = $updatedAt;
     }
 
-    final public function getUpdatedAt(): ?\DateTimeInterface
+    public function getUpdatedAt(): ?\DateTimeInterface
     {
         return $this->updatedAt;
     }
@@ -75,12 +75,12 @@ abstract class Context implements ContextInterface
         $this->setUpdatedAt(new \DateTime());
     }
 
-    final public function setId(?string $id): void
+    public function setId(?string $id): void
     {
         $this->id = $id;
     }
 
-    final public function getId(): ?string
+    public function getId(): ?string
     {
         return $this->id;
     }

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -34,54 +34,54 @@ abstract class Tag implements TagInterface
         return $this->getName() ?? 'n/a';
     }
 
-    final public function setName(?string $name): void
+    public function setName(?string $name): void
     {
         $this->name = $name;
 
         $this->setSlug($name);
     }
 
-    final public function getName(): ?string
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    final public function setEnabled(bool $enabled): void
+    public function setEnabled(bool $enabled): void
     {
         $this->enabled = $enabled;
     }
 
-    final public function getEnabled(): bool
+    public function getEnabled(): bool
     {
         return $this->enabled;
     }
 
-    final public function setSlug(?string $slug): void
+    public function setSlug(?string $slug): void
     {
         $this->slug = self::slugify($slug ?? '');
     }
 
-    final public function getSlug(): ?string
+    public function getSlug(): ?string
     {
         return $this->slug;
     }
 
-    final public function setCreatedAt(?\DateTimeInterface $createdAt): void
+    public function setCreatedAt(?\DateTimeInterface $createdAt): void
     {
         $this->createdAt = $createdAt;
     }
 
-    final public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeInterface
     {
         return $this->createdAt;
     }
 
-    final public function setUpdatedAt(?\DateTimeInterface $updatedAt): void
+    public function setUpdatedAt(?\DateTimeInterface $updatedAt): void
     {
         $this->updatedAt = $updatedAt;
     }
 
-    final public function getUpdatedAt(): ?\DateTimeInterface
+    public function getUpdatedAt(): ?\DateTimeInterface
     {
         return $this->updatedAt;
     }
@@ -94,7 +94,7 @@ abstract class Tag implements TagInterface
     /**
      * @see http://snipplr.com/view/22741/slugify-a-string-in-php/.
      */
-    final public static function slugify(string $text): string
+    public static function slugify(string $text): string
     {
         $text = Slugify::create()->slugify($text);
 
@@ -105,12 +105,12 @@ abstract class Tag implements TagInterface
         return $text;
     }
 
-    final public function setContext(?ContextInterface $context): void
+    public function setContext(?ContextInterface $context): void
     {
         $this->context = $context;
     }
 
-    final public function getContext(): ?ContextInterface
+    public function getContext(): ?ContextInterface
     {
         return $this->context;
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because bugfix.

Same PR than https://github.com/sonata-project/SonataMediaBundle/pull/2264

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataClassificationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Final modifier on all the getters / setters of the entities.
```