### PR TITLE
Backport changes from AdminBundle to CategoryAdminController

### DIFF
--- a/tests/App/Action/CategoryAdminTest.php
+++ b/tests/App/Action/CategoryAdminTest.php
@@ -21,7 +21,7 @@ use Sonata\ClassificationBundle\Tests\App\Entity\Context;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpKernel\KernelInterface;
 
-final class CartegoryAdminTest extends WebTestCase
+final class CategoryAdminTest extends WebTestCase
 {
     /**
      * @dataProvider provideCrudUrlsCases
@@ -44,6 +44,7 @@ final class CartegoryAdminTest extends WebTestCase
      */
     public static function provideCrudUrlsCases(): iterable
     {
+        yield 'List' => ['/admin/tests/app/category/list?filter%5Bcontext%5D%5Bvalue%5D='];
         yield 'Tree' => ['/admin/tests/app/category/tree'];
         yield 'Create' => ['/admin/tests/app/category/create'];
         yield 'Edit' => ['/admin/tests/app/category/1/edit'];


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

There was a template error, because the `export_formats` variable does not exist.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataClassificationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Backport changes from AdminBundle to `CategoryAdminController`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
