### PR TITLE
Fix edit group translation

### DIFF
--- a/src/Admin/CategoryAdmin.php
+++ b/src/Admin/CategoryAdmin.php
@@ -44,7 +44,7 @@ final class CategoryAdmin extends ContextAwareAdmin
     protected function configureFormFields(FormMapper $form): void
     {
         $form
-            ->with('group_general', ['class' => 'col-md-6'])
+            ->with('general', ['class' => 'col-md-6'])
                 ->add('name')
                 ->add('description', TextareaType::class, [
                     'required' => false,
@@ -67,7 +67,7 @@ final class CategoryAdmin extends ContextAwareAdmin
 
         $form
             ->end()
-            ->with('group_options', ['class' => 'col-md-6'])
+            ->with('options', ['class' => 'col-md-6'])
                 ->add('enabled', CheckboxType::class, [
                     'required' => false,
                 ])

--- a/src/Resources/translations/SonataClassificationBundle.de.xliff
+++ b/src/Resources/translations/SonataClassificationBundle.de.xliff
@@ -206,12 +206,12 @@
         <source>form.label_class</source>
         <target>CSS Klasse</target>
       </trans-unit>
-      <trans-unit id="group_general">
-        <source>group_general</source>
+      <trans-unit id="form.group_general">
+        <source>form.group_general</source>
         <target>Allgemein</target>
       </trans-unit>
-      <trans-unit id="group_options">
-        <source>group_options</source>
+      <trans-unit id="form.group_options">
+        <source>form.group_options</source>
         <target>Optionen</target>
       </trans-unit>
     </body>

--- a/src/Resources/translations/SonataClassificationBundle.en.xliff
+++ b/src/Resources/translations/SonataClassificationBundle.en.xliff
@@ -230,12 +230,12 @@
         <source>form.label_class</source>
         <target>CSS Class</target>
       </trans-unit>
-      <trans-unit id="group_general">
-        <source>group_general</source>
+      <trans-unit id="form.group_general">
+        <source>form.group_general</source>
         <target>General</target>
       </trans-unit>
-      <trans-unit id="group_options">
-        <source>group_options</source>
+      <trans-unit id="form.group_options">
+        <source>form.group_options</source>
         <target>Options</target>
       </trans-unit>
     </body>

--- a/src/Resources/translations/SonataClassificationBundle.fr.xliff
+++ b/src/Resources/translations/SonataClassificationBundle.fr.xliff
@@ -222,12 +222,12 @@
         <source>form.label_class</source>
         <target>Classe CSS</target>
       </trans-unit>
-      <trans-unit id="group_general">
-        <source>group_general</source>
+      <trans-unit id="form.group_general">
+        <source>form.group_general</source>
         <target>Général</target>
       </trans-unit>
-      <trans-unit id="group_options">
-        <source>group_options</source>
+      <trans-unit id="form.group_options">
+        <source>form.group_options</source>
         <target>Options</target>
       </trans-unit>
     </body>

--- a/src/Resources/translations/SonataClassificationBundle.hu.xliff
+++ b/src/Resources/translations/SonataClassificationBundle.hu.xliff
@@ -194,12 +194,12 @@
         <source>no_tags_found</source>
         <target>Címke nem található</target>
       </trans-unit>
-      <trans-unit id="group_general">
-        <source>group_general</source>
+      <trans-unit id="form.group_general">
+        <source>form.group_general</source>
         <target>Általános</target>
       </trans-unit>
-      <trans-unit id="group_options">
-        <source>group_options</source>
+      <trans-unit id="form.group_options">
+        <source>form.group_options</source>
         <target>Opciók</target>
       </trans-unit>
     </body>

--- a/src/Resources/translations/SonataClassificationBundle.it.xliff
+++ b/src/Resources/translations/SonataClassificationBundle.it.xliff
@@ -230,12 +230,12 @@
         <source>form.label_class</source>
         <target>Classe CSS</target>
       </trans-unit>
-      <trans-unit id="group_general">
-        <source>group_general</source>
+      <trans-unit id="form.group_general">
+        <source>form.group_general</source>
         <target>Generale</target>
       </trans-unit>
-      <trans-unit id="group_options">
-        <source>group_options</source>
+      <trans-unit id="form.group_options">
+        <source>form.group_options</source>
         <target>Opzioni</target>
       </trans-unit>
     </body>

--- a/src/Resources/translations/SonataClassificationBundle.nl.xliff
+++ b/src/Resources/translations/SonataClassificationBundle.nl.xliff
@@ -230,12 +230,12 @@
         <source>form.label_class</source>
         <target>CSS Class</target>
       </trans-unit>
-      <trans-unit id="group_general">
-        <source>group_general</source>
+      <trans-unit id="form.group_general">
+        <source>form.group_general</source>
         <target>Algemeen</target>
       </trans-unit>
-      <trans-unit id="group_options">
-        <source>group_options</source>
+      <trans-unit id="form.group_options">
+        <source>form.group_options</source>
         <target>Opties</target>
       </trans-unit>
     </body>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

The group translation was changed with the 4.0 release (two years ago):
https://github.com/sonata-project/SonataAdminBundle/commit/0353882955fafd25b200b9200615edd5670a5577#diff-2a4bc246b633572c2ffb06d2570f86047d06b8da1c90b850bb244740137136c8R73

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a patch.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataClassificationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix edit group translation
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
