### PR TITLE
Solve adminbundle deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.16",
         "psalm/plugin-symfony": "^3.0",
-        "sonata-project/admin-bundle": "^4.0.1",
+        "sonata-project/admin-bundle": "^4.9",
         "sonata-project/block-bundle": "^4.0",
         "sonata-project/doctrine-mongodb-admin-bundle": "^4.0",
         "sonata-project/doctrine-orm-admin-bundle": "^4.0",
@@ -73,7 +73,7 @@
     "conflict": {
         "doctrine/mongodb-odm": "<2.2",
         "doctrine/orm": "<2.9",
-        "sonata-project/admin-bundle": "<4.0.1",
+        "sonata-project/admin-bundle": "<4.9",
         "sonata-project/block-bundle": "<4.0",
         "sonata-project/doctrine-mongodb-admin-bundle": "<4.0",
         "sonata-project/doctrine-orm-admin-bundle": "<4.0"

--- a/src/Admin/ContextAwareAdmin.php
+++ b/src/Admin/ContextAwareAdmin.php
@@ -27,13 +27,32 @@ abstract class ContextAwareAdmin extends AbstractAdmin
     protected ContextManagerInterface $contextManager;
 
     /**
-     * @phpstan-param class-string<T> $class
+     * NEXT_MAJOR: Change signature to (ContextManagerInterface).
+     *
+     * @param ContextManagerInterface|string $contextManager
+     *
+     * @phpstan-param class-string<T>|null $deprecatedClass
      */
-    public function __construct(string $code, string $class, string $baseControllerName, ContextManagerInterface $contextManager)
-    {
-        parent::__construct($code, $class, $baseControllerName);
+    public function __construct(
+        $contextManager,
+        ?string $deprecatedClass = null,
+        ?string $deprecatedBaseControllerName = null,
+        ?ContextManagerInterface $deprecatedContextManager = null
+    ) {
+        // NEXT_MAJOR: Keep the if part.
+        if ($contextManager instanceof ContextManagerInterface) {
+            parent::__construct();
 
-        $this->contextManager = $contextManager;
+            $this->contextManager = $contextManager;
+        } else {
+            \assert(\is_string($deprecatedClass));
+            \assert(\is_string($deprecatedBaseControllerName));
+            \assert(null !== $deprecatedContextManager);
+
+            parent::__construct($contextManager, $deprecatedClass, $deprecatedBaseControllerName);
+
+            $this->contextManager = $deprecatedContextManager;
+        }
     }
 
     protected function alterNewInstance(object $object): void

--- a/src/Resources/config/admin.php
+++ b/src/Resources/config/admin.php
@@ -32,7 +32,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->tag('sonata.admin', [
                 'manager_type' => 'orm',
                 'group' => '%sonata.classification.admin.groupname%',
-                'label_catalogue' => '%sonata.classification.admin.category.translation_domain%',
+                'translation_domain' => '%sonata.classification.admin.category.translation_domain%',
                 'label' => 'label_categories',
                 'label_translator_strategy' => 'sonata.admin.label.strategy.underscore',
                 'icon' => '%sonata.classification.admin.groupicon%',
@@ -43,7 +43,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 '%sonata.classification.admin.category.controller%',
                 new ReferenceConfigurator('sonata.classification.manager.context'),
             ])
-            ->call('setTranslationDomain', ['%sonata.classification.admin.category.translation_domain%'])
             ->call('setTemplates', [[
                 'list' => '@SonataClassification/CategoryAdmin/list.html.twig',
                 'tree' => '@SonataClassification/CategoryAdmin/tree.html.twig',
@@ -54,7 +53,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->tag('sonata.admin', [
                 'manager_type' => 'orm',
                 'group' => '%sonata.classification.admin.groupname%',
-                'label_catalogue' => '%sonata.classification.admin.tag.translation_domain%',
+                'translation_domain' => '%sonata.classification.admin.tag.translation_domain%',
                 'label' => 'label_tags',
                 'label_translator_strategy' => 'sonata.admin.label.strategy.underscore',
                 'icon' => '%sonata.classification.admin.groupicon%',
@@ -65,14 +64,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 '%sonata.classification.admin.tag.controller%',
                 new ReferenceConfigurator('sonata.classification.manager.context'),
             ])
-            ->call('setTranslationDomain', ['%sonata.classification.admin.tag.translation_domain%'])
 
         ->set('sonata.classification.admin.collection', '%sonata.classification.admin.collection.class%')
             ->public()
             ->tag('sonata.admin', [
                 'manager_type' => 'orm',
                 'group' => '%sonata.classification.admin.groupname%',
-                'label_catalogue' => '%sonata.classification.admin.collection.translation_domain%',
+                'translation_domain' => '%sonata.classification.admin.collection.translation_domain%',
                 'label' => 'label_collections',
                 'label_translator_strategy' => 'sonata.admin.label.strategy.underscore',
                 'icon' => '%sonata.classification.admin.groupicon%',
@@ -83,14 +81,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 '%sonata.classification.admin.collection.controller%',
                 new ReferenceConfigurator('sonata.classification.manager.context'),
             ])
-            ->call('setTranslationDomain', ['%sonata.classification.admin.collection.translation_domain%'])
 
         ->set('sonata.classification.admin.context', '%sonata.classification.admin.context.class%')
             ->public()
             ->tag('sonata.admin', [
                 'manager_type' => 'orm',
                 'group' => '%sonata.classification.admin.groupname%',
-                'label_catalogue' => '%sonata.classification.admin.context.translation_domain%',
+                'translation_domain' => '%sonata.classification.admin.context.translation_domain%',
                 'label' => 'label_contexts',
                 'label_translator_strategy' => 'sonata.admin.label.strategy.underscore',
                 'icon' => '%sonata.classification.admin.groupicon%',
@@ -100,7 +97,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 '%sonata.classification.admin.context.entity%',
                 '%sonata.classification.admin.context.controller%',
             ])
-            ->call('setTranslationDomain', ['%sonata.classification.admin.collection.translation_domain%'])
 
         ->set(CategoryFilter::class)
             ->tag('sonata.admin.filter.type')

--- a/src/Resources/config/admin.php
+++ b/src/Resources/config/admin.php
@@ -30,6 +30,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set('sonata.classification.admin.category', '%sonata.classification.admin.category.class%')
             ->public()
             ->tag('sonata.admin', [
+                'model_class' => '%sonata.classification.admin.category.entity%',
+                'controller' => '%sonata.classification.admin.category.controller%',
                 'manager_type' => 'orm',
                 'group' => '%sonata.classification.admin.groupname%',
                 'translation_domain' => '%sonata.classification.admin.category.translation_domain%',
@@ -38,9 +40,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'icon' => '%sonata.classification.admin.groupicon%',
             ])
             ->args([
-                '',
-                '%sonata.classification.admin.category.entity%',
-                '%sonata.classification.admin.category.controller%',
                 new ReferenceConfigurator('sonata.classification.manager.context'),
             ])
             ->call('setTemplates', [[
@@ -51,6 +50,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set('sonata.classification.admin.tag', '%sonata.classification.admin.tag.class%')
             ->public()
             ->tag('sonata.admin', [
+                'model_class' => '%sonata.classification.admin.tag.entity%',
+                'controller' => '%sonata.classification.admin.tag.controller%',
                 'manager_type' => 'orm',
                 'group' => '%sonata.classification.admin.groupname%',
                 'translation_domain' => '%sonata.classification.admin.tag.translation_domain%',
@@ -59,15 +60,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'icon' => '%sonata.classification.admin.groupicon%',
             ])
             ->args([
-                '',
-                '%sonata.classification.admin.tag.entity%',
-                '%sonata.classification.admin.tag.controller%',
                 new ReferenceConfigurator('sonata.classification.manager.context'),
             ])
 
         ->set('sonata.classification.admin.collection', '%sonata.classification.admin.collection.class%')
             ->public()
             ->tag('sonata.admin', [
+                'model_class' => '%sonata.classification.admin.collection.entity%',
+                'controller' => '%sonata.classification.admin.collection.controller%',
                 'manager_type' => 'orm',
                 'group' => '%sonata.classification.admin.groupname%',
                 'translation_domain' => '%sonata.classification.admin.collection.translation_domain%',
@@ -76,26 +76,20 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'icon' => '%sonata.classification.admin.groupicon%',
             ])
             ->args([
-                '',
-                '%sonata.classification.admin.collection.entity%',
-                '%sonata.classification.admin.collection.controller%',
                 new ReferenceConfigurator('sonata.classification.manager.context'),
             ])
 
         ->set('sonata.classification.admin.context', '%sonata.classification.admin.context.class%')
             ->public()
             ->tag('sonata.admin', [
+                'model_class' => '%sonata.classification.admin.context.entity%',
+                'controller' => '%sonata.classification.admin.context.controller%',
                 'manager_type' => 'orm',
                 'group' => '%sonata.classification.admin.groupname%',
                 'translation_domain' => '%sonata.classification.admin.context.translation_domain%',
                 'label' => 'label_contexts',
                 'label_translator_strategy' => 'sonata.admin.label.strategy.underscore',
                 'icon' => '%sonata.classification.admin.groupicon%',
-            ])
-            ->args([
-                '',
-                '%sonata.classification.admin.context.entity%',
-                '%sonata.classification.admin.context.controller%',
             ])
 
         ->set(CategoryFilter::class)

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -19,7 +19,6 @@ use Sonata\AdminBundle\Admin\AdminExtensionInterface;
 use Sonata\ClassificationBundle\Admin\ContextAdmin;
 use Sonata\ClassificationBundle\Admin\ContextAwareAdmin;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
-use Sonata\ClassificationBundle\Tests\App\Entity\Context;
 
 final class AdminTest extends TestCase
 {
@@ -37,7 +36,7 @@ final class AdminTest extends TestCase
     {
         $contextAwareAdmin = $this->createMock(ContextAwareAdmin::class);
         static::assertInstanceOf(AbstractAdmin::class, $contextAwareAdmin);
-        $contextAdmin = new ContextAdmin('code', Context::class, 'controller');
+        $contextAdmin = new ContextAdmin();
         static::assertInstanceOf(AbstractAdmin::class, $contextAdmin);
     }
 
@@ -49,7 +48,7 @@ final class AdminTest extends TestCase
         ];
 
         $admin = $this->getMockForAbstractClass(ContextAwareAdmin::class, [
-            'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin', $this->contextManager,
+            $this->contextManager,
         ]);
 
         static::assertSame($expected, $admin->getPersistentParameters());
@@ -58,7 +57,7 @@ final class AdminTest extends TestCase
     public function testGetPersistentParametersWithValidExtension(): void
     {
         $admin = $this->getMockForAbstractClass(ContextAwareAdmin::class, [
-            'admin.my_code', 'My\Class', 'MyBundle:ClassAdmin', $this->contextManager,
+            $this->contextManager,
         ]);
 
         $extension = $this->createMock(AdminExtensionInterface::class);

--- a/tests/Block/Service/AbstractCategoriesBlockServiceTest.php
+++ b/tests/Block/Service/AbstractCategoriesBlockServiceTest.php
@@ -21,7 +21,6 @@ use Sonata\ClassificationBundle\Block\Service\AbstractCategoriesBlockService;
 use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
-use Sonata\ClassificationBundle\Tests\App\Entity\Category;
 use Twig\Environment;
 
 /**
@@ -48,7 +47,7 @@ final class AbstractCategoriesBlockServiceTest extends BlockServiceTestCase
         $this->twig = $this->createMock(Environment::class);
         $this->contextManager = $this->createMock(ContextManagerInterface::class);
         $this->categoryManager = $this->createMock(CategoryManagerInterface::class);
-        $this->categoryAdmin = new CategoryAdmin('code', Category::class, 'controller', $this->contextManager);
+        $this->categoryAdmin = new CategoryAdmin($this->contextManager);
     }
 
     public function testDefaultSettings(): void

--- a/tests/Block/Service/AbstractCollectionsBlockServiceTest.php
+++ b/tests/Block/Service/AbstractCollectionsBlockServiceTest.php
@@ -21,7 +21,6 @@ use Sonata\ClassificationBundle\Block\Service\AbstractCollectionsBlockService;
 use Sonata\ClassificationBundle\Model\CollectionInterface;
 use Sonata\ClassificationBundle\Model\CollectionManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
-use Sonata\ClassificationBundle\Tests\App\Entity\Collection;
 use Twig\Environment;
 
 /**
@@ -48,7 +47,7 @@ final class AbstractCollectionsBlockServiceTest extends BlockServiceTestCase
         $this->twig = $this->createMock(Environment::class);
         $this->contextManager = $this->createMock(ContextManagerInterface::class);
         $this->collectionManager = $this->createMock(CollectionManagerInterface::class);
-        $this->collectionAdmin = new CollectionAdmin('code', Collection::class, 'controller', $this->contextManager);
+        $this->collectionAdmin = new CollectionAdmin($this->contextManager);
     }
 
     public function testDefaultSettings(): void

--- a/tests/Block/Service/AbstractTagsBlockServiceTest.php
+++ b/tests/Block/Service/AbstractTagsBlockServiceTest.php
@@ -21,7 +21,6 @@ use Sonata\ClassificationBundle\Block\Service\AbstractTagsBlockService;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 use Sonata\ClassificationBundle\Model\TagInterface;
 use Sonata\ClassificationBundle\Model\TagManagerInterface;
-use Sonata\ClassificationBundle\Tests\App\Entity\Tag;
 use Twig\Environment;
 
 /**
@@ -48,7 +47,7 @@ final class AbstractTagsBlockServiceTest extends BlockServiceTestCase
         $this->twig = $this->createMock(Environment::class);
         $this->contextManager = $this->createMock(ContextManagerInterface::class);
         $this->tagManager = $this->createMock(TagManagerInterface::class);
-        $this->tagAdmin = new TagAdmin('code', Tag::class, 'controller', $this->contextManager);
+        $this->tagAdmin = new TagAdmin($this->contextManager);
     }
 
     public function testDefaultSettings(): void


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Deprecations introduces by SonataAdminBundle 4.9.0
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
