### PR TITLE
Fix deprecations for commands while maintian lazyness

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.4 || ^8.0",
         "cocur/slugify": "^4.0",
         "doctrine/collections": "^1.6",
-        "doctrine/persistence": "^2.0",
+        "doctrine/persistence": "^2.0 || ^3.0",
         "sonata-project/doctrine-extensions": "^1.13",
         "sonata-project/form-extensions": "^1.4",
         "symfony/config": "^4.4.11 || ^5.4 || ^6.0",
@@ -94,6 +94,10 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "phpstan/extension-installer": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.4 || ^8.0",
         "cocur/slugify": "^4.0",
         "doctrine/collections": "^1.6",
-        "doctrine/persistence": "^2.0 || ^3.0",
+        "doctrine/persistence": "^2.0",
         "sonata-project/doctrine-extensions": "^1.13",
         "sonata-project/form-extensions": "^1.4",
         "symfony/config": "^4.4.11 || ^5.4 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "psalm/plugin-phpunit": "^0.16",
         "psalm/plugin-symfony": "^3.0",
         "sonata-project/admin-bundle": "^4.9",
-        "sonata-project/block-bundle": "^4.0",
+        "sonata-project/block-bundle": "^4.11",
         "sonata-project/doctrine-mongodb-admin-bundle": "^4.0",
         "sonata-project/doctrine-orm-admin-bundle": "^4.0",
         "symfony/asset": "^4.4 || ^5.4 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -94,10 +94,10 @@
         }
     },
     "config": {
-        "sort-packages": true,
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
             "phpstan/extension-installer": true
-        }
+        },
+        "sort-packages": true
     }
 }

--- a/src/Command/FixContextCommand.php
+++ b/src/Command/FixContextCommand.php
@@ -18,12 +18,15 @@ use Sonata\ClassificationBundle\Model\CollectionManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 use Sonata\ClassificationBundle\Model\TagManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'sonata:classification:fix-context', description: 'Generate the default context if none defined and attach the context to all elements')]
 final class FixContextCommand extends Command
 {
+    // TODO: Remove static properties when support for Symfony < 6.0 is dropped.
     protected static $defaultName = 'sonata:classification:fix-context';
     protected static $defaultDescription = 'Generate the default context if none defined and attach the context to all elements';
 
@@ -52,6 +55,8 @@ final class FixContextCommand extends Command
     public function configure(): void
     {
         \assert(null !== static::$defaultDescription);
+
+        // TODO: Remove setDescription when support for Symfony < 5.4 is dropped.
         $this->setDescription(static::$defaultDescription);
     }
 

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -16,6 +16,7 @@ namespace Sonata\ClassificationBundle\Tests\App;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Knp\Bundle\MenuBundle\KnpMenuBundle;
 use Sonata\AdminBundle\SonataAdminBundle;
+use Sonata\BlockBundle\Cache\HttpCacheHandler;
 use Sonata\BlockBundle\SonataBlockBundle;
 use Sonata\ClassificationBundle\SonataClassificationBundle;
 use Sonata\Doctrine\Bridge\Symfony\SonataDoctrineBundle;
@@ -92,6 +93,10 @@ final class AppKernel extends Kernel
             $loader->load(__DIR__.'/Resources/config/config_symfony_v5.yaml');
         } else {
             $loader->load(__DIR__.'/Resources/config/config_symfony_v4.yaml');
+        }
+
+        if (class_exists(HttpCacheHandler::class)) {
+            $loader->load(__DIR__.'/Resources/config/config_sonata_block_v4.yaml');
         }
 
         $container->setParameter('app.base_dir', $this->getBaseDir());

--- a/tests/App/Resources/config/config.yaml
+++ b/tests/App/Resources/config/config.yaml
@@ -11,6 +11,7 @@ framework:
         enable_annotations: false
     router:
         utf8: true
+    http_method_override: false
 
 security:
     role_hierarchy: null

--- a/tests/App/Resources/config/config_sonata_block_v4.yaml
+++ b/tests/App/Resources/config/config_sonata_block_v4.yaml
@@ -1,0 +1,2 @@
+sonata_block:
+    http_cache: false


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Avoid deprecations for console commands on Symfony 6.1.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
