### PR TITLE
Add edit button to admin lists

### DIFF
--- a/src/Admin/CategoryAdmin.php
+++ b/src/Admin/CategoryAdmin.php
@@ -100,6 +100,12 @@ final class CategoryAdmin extends ContextAwareAdmin
             ->add('position')
             ->add('parent', null, [
                 'sortable' => 'parent.name',
+            ])
+            ->add(ListMapper::NAME_ACTIONS, ListMapper::TYPE_ACTIONS, [
+                'translation_domain' => 'SonataAdminBundle',
+                'actions' => [
+                    'edit' => [],
+                ],
             ]);
     }
 }

--- a/src/Admin/CollectionAdmin.php
+++ b/src/Admin/CollectionAdmin.php
@@ -65,6 +65,12 @@ final class CollectionAdmin extends ContextAwareAdmin
             ])
             ->add('enabled', null, [
                 'editable' => true,
+            ])
+            ->add(ListMapper::NAME_ACTIONS, ListMapper::TYPE_ACTIONS, [
+                'translation_domain' => 'SonataAdminBundle',
+                'actions' => [
+                    'edit' => [],
+                ],
             ]);
     }
 }

--- a/src/Admin/ContextAdmin.php
+++ b/src/Admin/ContextAdmin.php
@@ -56,6 +56,12 @@ final class ContextAdmin extends AbstractAdmin
                 'editable' => true,
             ])
             ->add('createdAt')
-            ->add('updatedAt');
+            ->add('updatedAt')
+            ->add(ListMapper::NAME_ACTIONS, ListMapper::TYPE_ACTIONS, [
+                'translation_domain' => 'SonataAdminBundle',
+                'actions' => [
+                    'edit' => [],
+                ],
+            ]);
     }
 }

--- a/src/Admin/TagAdmin.php
+++ b/src/Admin/TagAdmin.php
@@ -60,6 +60,12 @@ final class TagAdmin extends ContextAwareAdmin
             ])
             ->add('enabled', null, ['editable' => true])
             ->add('createdAt')
-            ->add('updatedAt');
+            ->add('updatedAt')
+            ->add(ListMapper::NAME_ACTIONS, ListMapper::TYPE_ACTIONS, [
+                'translation_domain' => 'SonataAdminBundle',
+                'actions' => [
+                    'edit' => [],
+                ],
+            ]);
     }
 }


### PR DESCRIPTION

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #872.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataClassificationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Add always edit button for admin list pages.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
