### PR TITLE
fix: use cascade 'merge' only if available

### DIFF
--- a/src/DependencyInjection/SonataClassificationExtension.php
+++ b/src/DependencyInjection/SonataClassificationExtension.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\ClassificationBundle\DependencyInjection;
 
 use Doctrine\ORM\EntityManager;
+use Sonata\ClassificationBundle\Entity\BaseCategory;
 use Sonata\Doctrine\Mapper\Builder\OptionsBuilder;
 use Sonata\Doctrine\Mapper\DoctrineCollector;
 use Symfony\Component\Config\Definition\Processor;
@@ -134,15 +135,16 @@ final class SonataClassificationExtension extends Extension
                 ->addOrder('position', 'ASC')
         );
 
-        $categoryCascade = ['persist', 'refresh', 'detach'];
-        if (class_exists(EntityManager::class) && method_exists(EntityManager::class, 'merge')) { // @phpstan-ignore-line
-            $categoryCascade[] = 'merge';
+        $categoryCascade = ['persist', 'refresh', 'merge', 'detach'];
+        $categoryIsEntity = \in_array(BaseCategory::class, class_parents($config['class']['category']), true);
+        if ($categoryIsEntity && class_exists(EntityManager::class) && !method_exists(EntityManager::class, 'merge')) { // @phpstan-ignore-line
+            unset($categoryCascade[array_search('merge', $categoryCascade, true)]);
         }
         $collector->addAssociation(
             $config['class']['category'],
             'mapManyToOne',
             OptionsBuilder::createManyToOne('parent', $config['class']['category'])
-                ->cascade($categoryCascade)
+                ->cascade(array_values($categoryCascade))
                 ->inversedBy('children')
                 ->addJoin([
                     'name' => 'parent_id',

--- a/src/DependencyInjection/SonataClassificationExtension.php
+++ b/src/DependencyInjection/SonataClassificationExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\ClassificationBundle\DependencyInjection;
 
+use Doctrine\ORM\EntityManager;
 use Sonata\Doctrine\Mapper\Builder\OptionsBuilder;
 use Sonata\Doctrine\Mapper\DoctrineCollector;
 use Symfony\Component\Config\Definition\Processor;
@@ -133,11 +134,15 @@ final class SonataClassificationExtension extends Extension
                 ->addOrder('position', 'ASC')
         );
 
+        $categoryCascade = ['persist', 'refresh', 'detach'];
+        if (class_exists(EntityManager::class) && method_exists(EntityManager::class, 'merge')) { // @phpstan-ignore-line
+            $categoryCascade[] = 'merge';
+        }
         $collector->addAssociation(
             $config['class']['category'],
             'mapManyToOne',
             OptionsBuilder::createManyToOne('parent', $config['class']['category'])
-                ->cascade(['persist', 'refresh', 'merge', 'detach'])
+                ->cascade($categoryCascade)
                 ->inversedBy('children')
                 ->addJoin([
                     'name' => 'parent_id',


### PR DESCRIPTION
Closes #973.

@VincentLanglet  Check is not performed on `EntityManagerInterface` because there is no `merge` method declared in supported `doctrine/orm` versions. Previously it was inherited from `ObjectManager` in `doctrine/persistence`, but it was removed in persistence 3.0.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataClassificationBundle/releases,
    please keep it short and clear and to the point
-->

```markdown
### Fixed
- Use cascade `merge` only if it's available in `doctrine/orm`
```
